### PR TITLE
Fix Async endpoint discovery templates

### DIFF
--- a/Sources/SotoCodeGenerator/Templates/api+async.swift
+++ b/Sources/SotoCodeGenerator/Templates/api+async.swift
@@ -14,47 +14,53 @@
 
 extension Templates {
     static let apiAsyncTemplate = """
-    {{%CONTENT_TYPE:TEXT}}
-    {{>header}}
+        {{%CONTENT_TYPE:TEXT}}
+        {{>header}}
 
-    #if compiler(>=5.5) && canImport(_Concurrency)
+        #if compiler(>=5.5) && canImport(_Concurrency)
 
-    import SotoCore
+        import SotoCore
 
-    @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
-    extension {{ name }} {
+        @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+        extension {{ name }} {
 
-        // MARK: Async API Calls
-    {{#operations}}
+            // MARK: Async API Calls
+        {{#operations}}
 
-    {{#comment}}
-        /// {{.}}
-    {{/comment}}
-    {{#deprecated}}
-        @available(*, deprecated, message:"{{.}}")
-    {{/deprecated}}
-        public func {{funcName}}({{#inputShape}}_ input: {{.}}, {{/inputShape}}logger: {{logger}} = AWSClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws{{#outputShape}} -> {{.}}{{/outputShape}} {
-            return try await self.client.execute(operation: "{{name}}", path: "{{path}}", httpMethod: .{{httpMethod}}, serviceConfig: self.config{{#inputShape}}, input: input{{/inputShape}}{{#hostPrefix}}, hostPrefix: "{{{.}}}"{{/hostPrefix}}, logger: logger, on: eventLoop)
+        {{#comment}}
+            /// {{.}}
+        {{/comment}}
+        {{#documentationUrl}}
+            /// {{.}}
+        {{/documentationUrl}}
+        {{#deprecated}}
+            @available(*, deprecated, message:"{{.}}")
+        {{/deprecated}}
+            public func {{funcName}}({{#inputShape}}_ input: {{.}}, {{/inputShape}}logger: {{logger}} = AWSClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws{{#outputShape}} -> {{.}}{{/outputShape}} {
+                return try await self.client.execute(operation: "{{name}}", path: "{{path}}", httpMethod: .{{httpMethod}}, serviceConfig: self.config{{#inputShape}}, input: input{{/inputShape}}{{#endpointRequired}}, endpointDiscovery: .init(storage: self.endpointStorage, discover: self.getEndpoint, required: {{required}}){{/endpointRequired}}{{#hostPrefix}}, hostPrefix: "{{{.}}}"{{/hostPrefix}}, logger: logger, on: eventLoop)
+            }
+        {{/operations}}
+        {{#first(streamingOperations)}}
+
+            // MARK: Streaming Async API Calls
+        {{#streamingOperations}}
+
+        {{#comment}}
+            /// {{.}}
+        {{/comment}}
+        {{#documentationUrl}}
+            /// {{.}}
+        {{/documentationUrl}}
+        {{#deprecated}}
+            @available(*, deprecated, message:"{{.}}")
+        {{/deprecated}}
+            public func {{funcName}}Streaming({{#inputShape}}_ input: {{.}}, {{/inputShape}}logger: {{logger}} = AWSClient.loggingDisabled, on eventLoop: EventLoop? = nil, _ stream: @escaping ({{streaming}}, EventLoop) -> EventLoopFuture<Void>) async throws{{#outputShape}} -> {{.}}{{/outputShape}} {
+                return try await self.client.execute(operation: "{{name}}", path: "{{path}}", httpMethod: .{{httpMethod}}, serviceConfig: self.config{{#inputShape}}, input: input{{/inputShape}}{{#endpointRequired}}, endpointDiscovery: .init(storage: self.endpointStorage, discover: self.getEndpoint, required: {{required}}){{/endpointRequired}}{{#hostPrefix}}, hostPrefix: "{{{.}}}"{{/hostPrefix}}, logger: logger, on: eventLoop, stream: stream)
+            }
+        {{/streamingOperations}}
+        {{/first(streamingOperations)}}
         }
-    {{/operations}}
-    {{#first(streamingOperations)}}
 
-        // MARK: Streaming Async API Calls
-    {{#streamingOperations}}
-
-    {{#comment}}
-        /// {{.}}
-    {{/comment}}
-    {{#deprecated}}
-        @available(*, deprecated, message:"{{.}}")
-    {{/deprecated}}
-        public func {{funcName}}Streaming({{#inputShape}}_ input: {{.}}, {{/inputShape}}logger: {{logger}} = AWSClient.loggingDisabled, on eventLoop: EventLoop? = nil, _ stream: @escaping ({{streaming}}, EventLoop) -> EventLoopFuture<Void>) async throws{{#outputShape}} -> {{.}}{{/outputShape}} {
-            return try await self.client.execute(operation: "{{name}}", path: "{{path}}", httpMethod: .{{httpMethod}}, serviceConfig: self.config{{#inputShape}}, input: input{{/inputShape}}{{#hostPrefix}}, hostPrefix: "{{{.}}}"{{/hostPrefix}}, logger: logger, on: eventLoop, stream: stream)
-        }
-    {{/streamingOperations}}
-    {{/first(streamingOperations)}}
-    }
-
-    #endif // compiler(>=5.5) && canImport(_Concurrency)
-    """
+        #endif // compiler(>=5.5) && canImport(_Concurrency)
+        """
 }

--- a/Sources/SotoCodeGenerator/Templates/api.swift
+++ b/Sources/SotoCodeGenerator/Templates/api.swift
@@ -133,11 +133,14 @@ extension Templates {
         {{#comment}}
             /// {{.}}
         {{/comment}}
+        {{#documentationUrl}}
+            /// {{.}}
+        {{/documentationUrl}}
         {{#deprecated}}
             @available(*, deprecated, message:"{{.}}")
         {{/deprecated}}
             {{^outputShape}}@discardableResult {{/outputShape}}public func {{funcName}}Streaming({{#inputShape}}_ input: {{.}}, {{/inputShape}}logger: {{logger}} = AWSClient.loggingDisabled, on eventLoop: EventLoop? = nil{{#streaming}}, _ stream: @escaping ({{.}}, EventLoop)->EventLoopFuture<Void>{{/streaming}}) -> EventLoopFuture<{{#outputShape}}{{.}}{{/outputShape}}{{^outputShape}}Void{{/outputShape}}> {
-                return self.client.execute(operation: "{{name}}", path: "{{path}}", httpMethod: .{{httpMethod}}, serviceConfig: self.config{{#inputShape}}, input: input{{/inputShape}}{{#hostPrefix}}, hostPrefix: "{{{.}}}"{{/hostPrefix}}, logger: logger, on: eventLoop{{#streaming}}, stream: stream{{/streaming}})
+                return self.client.execute(operation: "{{name}}", path: "{{path}}", httpMethod: .{{httpMethod}}, serviceConfig: self.config{{#inputShape}}, input: input{{/inputShape}}{{#endpointRequired}}, endpointDiscovery: .init(storage: self.endpointStorage, discover: self.getEndpoint, required: {{required}}){{/endpointRequired}}{{#hostPrefix}}, hostPrefix: "{{{.}}}"{{/hostPrefix}}, logger: logger, on: eventLoop{{#streaming}}, stream: stream{{/streaming}})
             }
         {{/streamingOperations}}
         {{/first(streamingOperations)}}


### PR DESCRIPTION
Endpoint discovery template changes were not pushed through to async templates. This PR resolves this issue.

You can see these code changes in `Sources/Soto/Services/TimestreamQuery/TimestreamQuery_API+async.swift` in PR https://github.com/soto-project/soto/pull/539