### PR TITLE
Add deprecated `init` function with deprecated shape members

### DIFF
--- a/Sources/SotoCodeGenerator/AwsService+shapes.swift
+++ b/Sources/SotoCodeGenerator/AwsService+shapes.swift
@@ -119,7 +119,8 @@ extension AwsService {
                     shapeOptions.append("allowStreaming")
                     if !payload.hasTrait(type: RequiresLengthTrait.self),
                        let operationShape = operationShape,
-                       operationShape.hasTrait(type: AwsAuthUnsignedPayloadTrait.self) {
+                       operationShape.hasTrait(type: AwsAuthUnsignedPayloadTrait.self)
+                    {
                         shapeOptions.append("allowChunkedStreaming")
                     }
                 }

--- a/Sources/SotoCodeGenerator/AwsService.swift
+++ b/Sources/SotoCodeGenerator/AwsService.swift
@@ -41,7 +41,6 @@ struct AwsService {
         self.serviceEndpointPrefix = try Self.getServiceEndpointPrefix(service: service.value, id: service.key) ?? serviceName.lowercased()
         self.serviceProtocolTrait = try Self.getServiceProtocol(service.value)
 
-
         self.operations = Self.getOperations(service.value, model: model)
 
         self.endpoints = endpoints
@@ -70,7 +69,7 @@ struct AwsService {
             .components(separatedBy: CharacterSet.alphanumerics.inverted)
             .map { $0.prefix(1).capitalized + $0.dropFirst() }
             .joined()
-        
+
         return serviceName
     }
 
@@ -106,7 +105,7 @@ struct AwsService {
         context["xmlNamespace"] = service.trait(type: XmlNamespaceTrait.self)?.uri
         context["middlewareClass"] = self.getMiddleware(for: service)
         context["endpointDiscovery"] = service.trait(type: AwsClientEndpointDiscoveryTrait.self)?.operation.shapeName.toSwiftVariableCase()
-        
+
         let endpoints = self.getServiceEndpoints()
             .sorted { $0.key < $1.key }
             .map { "\"\($0.key)\": \"\($0.value)\"" }
@@ -554,7 +553,7 @@ struct AwsService {
     // return dictionary of partition endpoints keyed by endpoint name
     func getPartitionEndpoints() -> [String: (endpoint: String, region: Region)] {
         var partitionEndpoints: [String: (endpoint: String, region: Region)] = [:]
-        endpoints.partitions.forEach {
+        self.endpoints.partitions.forEach {
             if let partitionEndpoint = $0.services[self.serviceEndpointPrefix]?.partitionEndpoint {
                 guard let service = $0.services[self.serviceEndpointPrefix],
                       let endpoint = service.endpoints[partitionEndpoint],
@@ -609,6 +608,7 @@ extension AwsService {
         struct DiscoverableEndpoint {
             let required: Bool
         }
+
         let comment: [String.SubSequence]
         let funcName: String
         let inputShape: String?

--- a/Sources/SotoCodeGenerator/AwsService.swift
+++ b/Sources/SotoCodeGenerator/AwsService.swift
@@ -157,6 +157,8 @@ struct AwsService {
             // construct array of input shape parameters to use in `usingPaginationToken` function
             var initParams: [String: String] = [:]
             for member in inputShape.members ?? [:] {
+                // don't include deprecated members
+                guard !member.value.hasTrait(type: DeprecatedTrait.self) else { continue }
                 initParams[member.key.toSwiftLabelCase()] = "self.\(member.key.toSwiftLabelCase())"
             }
             initParams[inputToken.toSwiftLabelCase()] = "token"
@@ -670,7 +672,14 @@ extension AwsService {
         let propertyWrapper: String?
         let type: String
         let comment: [String.SubSequence]
+        let deprecated: Bool
         var duplicate: Bool
+    }
+
+    struct InitParamContext {
+        let parameter: String
+        let type: String
+        let `default`: String?
     }
 
     struct MemberEncodingContext {
@@ -735,10 +744,12 @@ extension AwsService {
         let isDecodable: Bool
         let encoding: [EncodingPropertiesContext]
         let members: [MemberContext]
+        let initParameters: [InitParamContext]
         let awsShapeMembers: [MemberEncodingContext]
         let codingKeys: [CodingKeysContext]
         let validation: [ValidationContext]
         let requiresDefaultValidation: Bool
+        let deprecatedMembers: [String]
     }
 
     struct WaiterContext {

--- a/Sources/SotoCodeGenerator/Patch.swift
+++ b/Sources/SotoCodeGenerator/Patch.swift
@@ -99,7 +99,7 @@ struct MultiplePatch: ShapePatch {
     init(_ patches: ShapePatch...) {
         self.init(patches)
     }
-    
+
     func patch(shape: Shape) throws -> Shape? {
         var shape = shape
         for patch in self.patches {

--- a/Sources/SotoCodeGenerator/SotoTraits.swift
+++ b/Sources/SotoCodeGenerator/SotoTraits.swift
@@ -59,6 +59,7 @@ public struct SotoPaginationTruncatedTrait: StaticTrait {
             OrSelector(TypeSelector<OperationShape>(), TypeSelector<ServiceShape>())
         )
     }
+
     public let isTruncated: String
 
     public init(isTruncated: String) {

--- a/Sources/SotoCodeGenerator/Templates/api+async.swift
+++ b/Sources/SotoCodeGenerator/Templates/api+async.swift
@@ -14,53 +14,53 @@
 
 extension Templates {
     static let apiAsyncTemplate = """
-        {{%CONTENT_TYPE:TEXT}}
-        {{>header}}
+    {{%CONTENT_TYPE:TEXT}}
+    {{>header}}
 
-        #if compiler(>=5.5) && canImport(_Concurrency)
+    #if compiler(>=5.5) && canImport(_Concurrency)
 
-        import SotoCore
+    import SotoCore
 
-        @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
-        extension {{ name }} {
+    @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+    extension {{ name }} {
 
-            // MARK: Async API Calls
-        {{#operations}}
+        // MARK: Async API Calls
+    {{#operations}}
 
-        {{#comment}}
-            /// {{.}}
-        {{/comment}}
-        {{#documentationUrl}}
-            /// {{.}}
-        {{/documentationUrl}}
-        {{#deprecated}}
-            @available(*, deprecated, message:"{{.}}")
-        {{/deprecated}}
-            public func {{funcName}}({{#inputShape}}_ input: {{.}}, {{/inputShape}}logger: {{logger}} = AWSClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws{{#outputShape}} -> {{.}}{{/outputShape}} {
-                return try await self.client.execute(operation: "{{name}}", path: "{{path}}", httpMethod: .{{httpMethod}}, serviceConfig: self.config{{#inputShape}}, input: input{{/inputShape}}{{#endpointRequired}}, endpointDiscovery: .init(storage: self.endpointStorage, discover: self.getEndpoint, required: {{required}}){{/endpointRequired}}{{#hostPrefix}}, hostPrefix: "{{{.}}}"{{/hostPrefix}}, logger: logger, on: eventLoop)
-            }
-        {{/operations}}
-        {{#first(streamingOperations)}}
-
-            // MARK: Streaming Async API Calls
-        {{#streamingOperations}}
-
-        {{#comment}}
-            /// {{.}}
-        {{/comment}}
-        {{#documentationUrl}}
-            /// {{.}}
-        {{/documentationUrl}}
-        {{#deprecated}}
-            @available(*, deprecated, message:"{{.}}")
-        {{/deprecated}}
-            public func {{funcName}}Streaming({{#inputShape}}_ input: {{.}}, {{/inputShape}}logger: {{logger}} = AWSClient.loggingDisabled, on eventLoop: EventLoop? = nil, _ stream: @escaping ({{streaming}}, EventLoop) -> EventLoopFuture<Void>) async throws{{#outputShape}} -> {{.}}{{/outputShape}} {
-                return try await self.client.execute(operation: "{{name}}", path: "{{path}}", httpMethod: .{{httpMethod}}, serviceConfig: self.config{{#inputShape}}, input: input{{/inputShape}}{{#endpointRequired}}, endpointDiscovery: .init(storage: self.endpointStorage, discover: self.getEndpoint, required: {{required}}){{/endpointRequired}}{{#hostPrefix}}, hostPrefix: "{{{.}}}"{{/hostPrefix}}, logger: logger, on: eventLoop, stream: stream)
-            }
-        {{/streamingOperations}}
-        {{/first(streamingOperations)}}
+    {{#comment}}
+        /// {{.}}
+    {{/comment}}
+    {{#documentationUrl}}
+        /// {{.}}
+    {{/documentationUrl}}
+    {{#deprecated}}
+        @available(*, deprecated, message:"{{.}}")
+    {{/deprecated}}
+        public func {{funcName}}({{#inputShape}}_ input: {{.}}, {{/inputShape}}logger: {{logger}} = AWSClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws{{#outputShape}} -> {{.}}{{/outputShape}} {
+            return try await self.client.execute(operation: "{{name}}", path: "{{path}}", httpMethod: .{{httpMethod}}, serviceConfig: self.config{{#inputShape}}, input: input{{/inputShape}}{{#endpointRequired}}, endpointDiscovery: .init(storage: self.endpointStorage, discover: self.getEndpoint, required: {{required}}){{/endpointRequired}}{{#hostPrefix}}, hostPrefix: "{{{.}}}"{{/hostPrefix}}, logger: logger, on: eventLoop)
         }
+    {{/operations}}
+    {{#first(streamingOperations)}}
 
-        #endif // compiler(>=5.5) && canImport(_Concurrency)
-        """
+        // MARK: Streaming Async API Calls
+    {{#streamingOperations}}
+
+    {{#comment}}
+        /// {{.}}
+    {{/comment}}
+    {{#documentationUrl}}
+        /// {{.}}
+    {{/documentationUrl}}
+    {{#deprecated}}
+        @available(*, deprecated, message:"{{.}}")
+    {{/deprecated}}
+        public func {{funcName}}Streaming({{#inputShape}}_ input: {{.}}, {{/inputShape}}logger: {{logger}} = AWSClient.loggingDisabled, on eventLoop: EventLoop? = nil, _ stream: @escaping ({{streaming}}, EventLoop) -> EventLoopFuture<Void>) async throws{{#outputShape}} -> {{.}}{{/outputShape}} {
+            return try await self.client.execute(operation: "{{name}}", path: "{{path}}", httpMethod: .{{httpMethod}}, serviceConfig: self.config{{#inputShape}}, input: input{{/inputShape}}{{#endpointRequired}}, endpointDiscovery: .init(storage: self.endpointStorage, discover: self.getEndpoint, required: {{required}}){{/endpointRequired}}{{#hostPrefix}}, hostPrefix: "{{{.}}}"{{/hostPrefix}}, logger: logger, on: eventLoop, stream: stream)
+        }
+    {{/streamingOperations}}
+    {{/first(streamingOperations)}}
+    }
+
+    #endif // compiler(>=5.5) && canImport(_Concurrency)
+    """
 }

--- a/Sources/SotoCodeGenerator/Templates/api.swift
+++ b/Sources/SotoCodeGenerator/Templates/api.swift
@@ -145,7 +145,7 @@ extension Templates {
         {{/streamingOperations}}
         {{/first(streamingOperations)}}
         {{#endpointDiscovery}}
-        
+
             func getEndpoint(logger: Logger, eventLoop: EventLoop) -> EventLoopFuture<AWSEndpoints> {
                 return describeEndpoints(.init(), logger: logger, on: eventLoop).map {
                     .init(endpoints: $0.endpoints.map {

--- a/Sources/SotoCodeGenerator/Templates/struct.swift
+++ b/Sources/SotoCodeGenerator/Templates/struct.swift
@@ -57,11 +57,25 @@ extension Templates {
     {{/members}}
 
     {{! init() function }}
+            public init({{#initParameters}}{{parameter}}: {{type}}{{#default}} = {{.}}{{/default}}{{^last()}}, {{/last()}}{{/initParameters}}) {
+    {{#members}}
+    {{^deprecated}}
+                self.{{variable}} = {{variable}}
+    {{/deprecated}}
+    {{#deprecated}}
+                self.{{variable}} = {{default}}
+    {{/deprecated}}
+    {{/members}}
+            }
+    {{! deprecated init() function }}
+    {{^empty(deprecatedMembers)}}
+            @available(*, deprecated, message:"Members {{#deprecatedMembers}}{{.}}{{^last()}}, {{/last()}}{{/deprecatedMembers}} have been deprecated")
             public init({{#members}}{{parameter}}: {{type}}{{#default}} = {{.}}{{/default}}{{^last()}}, {{/last()}}{{/members}}) {
     {{#members}}
                 self.{{variable}} = {{variable}}
     {{/members}}
             }
+    {{/empty(deprecatedMembers)}}
     {{! validate() function }}
     {{#first(validation)}}
 


### PR DESCRIPTION
For shapes with deprecated member variables
- remove deprecated variables from original `init`.
- create a second `init` which includes the deprecated variables as parameters and flag this as deprecated.