### PR TITLE
Add Stub trait for shapes that exist outside of current module

### DIFF
--- a/Sources/SotoCodeGenerator/AwsService.swift
+++ b/Sources/SotoCodeGenerator/AwsService.swift
@@ -457,6 +457,8 @@ struct AwsService {
     func markInputOutputShapes(_ model: Model) {
         func addTrait<T: StaticTrait>(to shapeId: ShapeId, trait: T) {
             guard let shape = model.shape(for: shapeId) else { return }
+            // don't mark shapes that are marked as stubs
+            guard shape.trait(type: SotoStubTrait.self) == nil else { return }
             // if shape already has trait then don't apply it again
             guard shape.trait(type: T.self) == nil else { return }
 

--- a/Sources/SotoCodeGenerator/Model+Patch.swift
+++ b/Sources/SotoCodeGenerator/Model+Patch.swift
@@ -18,6 +18,7 @@ import SotoSmithyAWS
 extension Model {
     static let patches: [String: [ShapeId: ShapePatch]] = [
         "Amplify": [
+            // https://github.com/soto-project/soto/issues/474
             "com.amazonaws.amplify#App$description": RemoveTraitPatch(trait: RequiredTrait.self),
             "com.amazonaws.amplify#App$environmentVariables": RemoveTraitPatch(trait: RequiredTrait.self),
             "com.amazonaws.amplify#App$repository": RemoveTraitPatch(trait: RequiredTrait.self),
@@ -35,51 +36,66 @@ extension Model {
             }
         ],
         "CloudWatch": [
+            // Dashboard not found code is the same as ResourceNotFound
             "com.amazonaws.cloudwatch#DashboardNotFoundError": RemoveTraitPatch(trait: AwsProtocolsAwsQueryErrorTrait.self),
         ],
         "Codeartifact": [
+            // service name change
             "com.amazonaws.codeartifact#CodeArtifactControlPlaneService": EditTraitPatch { trait -> AwsServiceTrait in trait.with(sdkId: "CodeArtifact") },
         ],
         "CodestarNotifications": [
+            // service name change
             "com.amazonaws.codestarnotifications#CodeStarNotifications_20191015": EditTraitPatch { trait -> AwsServiceTrait in trait.with(sdkId: "CodeStarNotifications") },
         ],
         "CognitoIdentityProvider": [
+            // https://github.com/soto-project/soto/issues/478
             "com.amazonaws.cognitoidentityprovider#UserStatusType": EditEnumPatch(add: [.init(value: "EXTERNAL_PROVIDER")]),
         ],
         "DynamoDB": [
+            // Make TransactWriteItem an enum with associated values
             "com.amazonaws.dynamodb#TransactWriteItem": EditShapePatch { (shape: StructureShape) in return UnionShape(traits: shape.traits, members: shape.members) },
         ],
         "EC2": [
             "com.amazonaws.ec2#PlatformValues": EditEnumPatch(add: [.init(value: "windows")], remove: ["Windows"]),
+            // make InstanceType and ArchitectureType extensible enums to avoid the situation where the
+            // sdk service files cannot keep up with the changes coming from the services
             "com.amazonaws.ec2#InstanceType": AddTraitPatch(trait: SotoExtensibleEnumTrait()),
             "com.amazonaws.ec2#ArchitectureType": AddTraitPatch(trait: SotoExtensibleEnumTrait()),
         ],
         "ECS": [
+            // https://github.com/soto-project/soto/issues/109
             "com.amazonaws.ecs#PropagateTags": EditEnumPatch(add: [.init(value: "NONE")]),
         ],
         "ECRPUBLIC": [
+            // service name change
             "com.amazonaws.ecrpublic#SpencerFrontendService": EditTraitPatch { trait -> AwsServiceTrait in trait.with(sdkId: "ECRPublic") },
         ],
         "ElasticLoadBalancing": [
+            // https://github.com/soto-project/soto/pull/88
             "com.amazonaws.elasticloadbalancing#SecurityGroupOwnerAlias": ShapeTypePatch(shape: IntegerShape()),
         ],
         "Fis": [
+            // service name change
             "com.amazonaws.fis#FaultInjectionSimulator": EditTraitPatch { trait -> AwsServiceTrait in trait.with(sdkId: "FIS") },
         ],
         "IAM": [
             "com.amazonaws.iam#PolicySourceType": EditEnumPatch(add: [.init(value: "IAM Policy")]),
         ],
         "Identitystore": [
+            // service name change
             "com.amazonaws.identitystore#AWSIdentityStore": EditTraitPatch { trait -> AwsServiceTrait in trait.with(sdkId: "IdentityStore") },
         ],
         "IotDeviceAdvisor": [
+            // service name change
             "com.amazonaws.iotdeviceadvisor#IotSenateService": EditTraitPatch { trait -> AwsServiceTrait in trait.with(sdkId: "IoTDeviceAdvisor") },
         ],
         "Ivs": [
+            // service name change
             "com.amazonaws.ivs#AmazonInteractiveVideoService": EditTraitPatch { trait -> AwsServiceTrait in trait.with(sdkId: "IVS") },
         ],
         "Lambda": [
-            // Replace lambda ListFunctionsRequest.MasterRegion with SotoCore.Region 
+            // Replace lambda ListFunctionsRequest.MasterRegion with SotoCore.Region. 
+            // See https://github.com/soto-project/soto/issues/382 
             "com.amazonaws.lambda#SotoCore.Region": CreateShapePatch(
                 shape: StringShape(),
                 patch: MultiplePatch(
@@ -92,37 +108,48 @@ extension Model {
             }
         ],
         "Mq": [
+            // service name change
             "com.amazonaws.mq#mq": EditTraitPatch { trait -> AwsServiceTrait in trait.with(sdkId: "MQ") },
         ],
         "RDSData": [
+            // See https://github.com/soto-project/soto/issues/471
             "com.amazonaws.rdsdata#Arn": EditTraitPatch { trait in return LengthTrait(min: trait.min, max: 2048) },
         ],
         "Route53": [
+            // pagination tokens in response shouldnt be required
             "com.amazonaws.route53#ListHealthChecksResponse$Marker": RemoveTraitPatch(trait: RequiredTrait.self),
             "com.amazonaws.route53#ListHostedZonesResponse$Marker": RemoveTraitPatch(trait: RequiredTrait.self),
             "com.amazonaws.route53#ListReusableDelegationSetsResponse$Marker": RemoveTraitPatch(trait: RequiredTrait.self),
         ],
         "S3": [
+            // https://github.com/soto-project/soto/issues/68
             "com.amazonaws.s3#ReplicationStatus": EditEnumPatch(add: [.init(value: "COMPLETED")], remove: ["COMPLETE"]),
+            // should be 64 bit number
             "com.amazonaws.s3#Size": ShapeTypePatch(shape: LongShape()),
+            // https://github.com/soto-project/soto/issues/311
             "com.amazonaws.s3#CopySource": EditTraitPatch { _ in return PatternTrait(value: ".+\\/.+") },
             "com.amazonaws.s3#LifecycleRule$Filter": AddTraitPatch(trait: RequiredTrait()),
+            // https://github.com/soto-project/soto/issues/502
             "com.amazonaws.s3#BucketLocationConstraint": MultiplePatch(
                 EditEnumPatch(add: [.init(value: "us-east-1")]),
                 AddTraitPatch(trait: SotoExtensibleEnumTrait())
             ),
+            // ListParts uses the IsTruncated flags to indicate when to finish pagination
             "com.amazonaws.s3#ListParts": AddTraitPatch(trait: SotoPaginationTruncatedTrait(isTruncated: "IsTruncated")),
         ],
         "S3Control": [
+            // Similar to the same issue in S3
             "com.amazonaws.s3control#BucketLocationConstraint": MultiplePatch([
                 EditEnumPatch(add: [.init(value: "us-east-1")]),
                 AddTraitPatch(trait: SotoExtensibleEnumTrait()),
             ]),
         ],
         "SageMaker": [
+            // pagination tokens in response shouldnt be required
             "com.amazonaws.sagemaker#ListFeatureGroupsResponse$NextToken": RemoveTraitPatch(trait: RequiredTrait.self),
         ],
         "Savingsplans": [
+            // service name change
             "com.amazonaws.savingsplans#AWSSavingsPlan": EditTraitPatch { trait -> AwsServiceTrait in trait.with(sdkId: "SavingsPlans") },
         ],
     ]

--- a/Sources/SotoCodeGenerator/Model+Patch.swift
+++ b/Sources/SotoCodeGenerator/Model+Patch.swift
@@ -78,10 +78,19 @@ extension Model {
         "Ivs": [
             "com.amazonaws.ivs#AmazonInteractiveVideoService": EditTraitPatch { trait -> AwsServiceTrait in trait.with(sdkId: "IVS") },
         ],
-        /* "Lambda": [
-                //AddDictionaryPatch(PatchKeyPath1(\.shapes), key: "SotoCore.Region", value: Shape(type: .stub, name: "SotoCore.Region")),
-                //ReplacePatch(PatchKeyPath4(\.shapes["ListFunctionsRequest"], \.type.structure, \.members["MasterRegion"], \.shapeName), value: "SotoCore.Region", originalValue: "MasterRegion"),
-            ], */
+        "Lambda": [
+            // Replace lambda ListFunctionsRequest.MasterRegion with SotoCore.Region 
+            "com.amazonaws.lambda#SotoCore.Region": CreateShapePatch(
+                shape: StringShape(),
+                patch: MultiplePatch(
+                    AddTraitPatch(trait: SotoStubTrait()),
+                    AddTraitPatch(trait: EnumTrait(value: .init([])))
+                )
+            ),
+            "com.amazonaws.lambda#ListFunctionsRequest$MasterRegion": EditShapePatch { (shape: MemberShape) in 
+                return MemberShape(target: "com.amazonaws.lambda#SotoCore.Region", traits: shape.traits)
+            }
+        ],
         "Mq": [
             "com.amazonaws.mq#mq": EditTraitPatch { trait -> AwsServiceTrait in trait.with(sdkId: "MQ") },
         ],

--- a/Sources/SotoCodeGenerator/Model+Patch.swift
+++ b/Sources/SotoCodeGenerator/Model+Patch.swift
@@ -79,6 +79,7 @@ extension Model {
             "com.amazonaws.fis#FaultInjectionSimulator": EditTraitPatch { trait -> AwsServiceTrait in trait.with(sdkId: "FIS") },
         ],
         "IAM": [
+            // Missing Enum value
             "com.amazonaws.iam#PolicySourceType": EditEnumPatch(add: [.init(value: "IAM Policy")]),
         ],
         "Identitystore": [

--- a/Sources/SotoCodeGenerator/Patch.swift
+++ b/Sources/SotoCodeGenerator/Patch.swift
@@ -36,14 +36,19 @@ struct EditShapePatch<S: Shape>: ShapePatch {
 
 struct CreateShapePatch: ShapePatch {
     let shape: Shape
-    let patch: ShapePatch
+    let patch: ShapePatch?
+
+    init(shape: Shape, patch: ShapePatch? = nil) {
+        self.shape = shape
+        self.patch = patch
+    }
 
     func create() throws -> Shape? {
         return try patch(shape: self.shape)
     }
 
     func patch(shape: Shape) throws -> Shape? {
-        return try patch.patch(shape: shape) ?? shape
+        return try patch?.patch(shape: shape) ?? shape
     }
 }
 

--- a/Sources/SotoCodeGenerator/SotoTraits.swift
+++ b/Sources/SotoCodeGenerator/SotoTraits.swift
@@ -50,6 +50,10 @@ struct SotoExtensibleEnumTrait: StaticTrait {
     var selector: Selector { TraitSelector<EnumTrait>() }
 }
 
+struct SotoStubTrait: StaticTrait {
+    static let staticName: ShapeId = "soto.api#stub"
+}
+
 /// Indicates that associated PaginatedTrait requires to check a `IsTruncated` flag
 public struct SotoPaginationTruncatedTrait: StaticTrait {
     public static var staticName: ShapeId = "soto.api#paginationTruncated"


### PR DESCRIPTION
A stub shape should not be serialised as it exists outside of the module being serialised. This is used for the region in Lambda.listFunctionsRequest