### PR TITLE
Swift Concurrency Availability macOS 10.15, iOS 13, tvOS 13, ...

### DIFF
--- a/Sources/SotoCodeGenerator/Templates/api+async.swift
+++ b/Sources/SotoCodeGenerator/Templates/api+async.swift
@@ -21,7 +21,7 @@ extension Templates {
 
     import SotoCore
 
-    @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     extension {{ name }} {
 
         // MARK: Async API Calls

--- a/Sources/SotoCodeGenerator/Templates/paginator+async.swift
+++ b/Sources/SotoCodeGenerator/Templates/paginator+async.swift
@@ -23,7 +23,7 @@ extension Templates {
 
     // MARK: Paginators
 
-    @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     extension {{name}} {
     {{#paginators}}
     {{#operation.comment}}

--- a/Sources/SotoCodeGenerator/Templates/waiter+async.swift
+++ b/Sources/SotoCodeGenerator/Templates/waiter+async.swift
@@ -23,7 +23,7 @@ extension Templates {
 
     // MARK: Waiters
 
-    @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     extension {{name}} {
     {{#waiters}}
         public func waitUntil{{waiterName}}(


### PR DESCRIPTION
Add new concurrency availability to templates