### PR TITLE
Replace self with _self

### DIFF
--- a/Sources/SotoCodeGeneratorLib/String.swift
+++ b/Sources/SotoCodeGeneratorLib/String.swift
@@ -78,6 +78,9 @@ extension String {
     }
 
     func reservedwordEscaped() -> String {
+        if self == "self" {
+            return "_self"
+        }
         if swiftReservedWords.contains(self) {
             return "`\(self)`"
         }


### PR DESCRIPTION
Stops these kind of errors
<unknown>:0: warning: 'self' refers to the method 'Imagebuilder.Ownership.self', which may be unexpected
<unknown>:0: note: use 'Imagebuilder.Ownership.self' to silence this warning

Plus `.self` is confusing. Is it the enum case or the enum?