### PR TITLE
If endpoint doesn't exist try and use arnNamespace instead

### DIFF
--- a/Sources/SotoCodeGeneratorLib/AwsService.swift
+++ b/Sources/SotoCodeGeneratorLib/AwsService.swift
@@ -79,7 +79,7 @@ struct AwsService {
     /// return service name used in endpoint. Uses filename of Smithy file
     static func getServiceEndpointPrefix(service: SotoSmithy.ServiceShape, id: ShapeId) throws -> String? {
         let awsService = try Self.getTrait(from: service, trait: AwsServiceTrait.self, id: id)
-        return awsService.endpointPrefix
+        return awsService.endpointPrefix ?? awsService.arnNamespace
     }
 
     /// Generate context for rendering service template


### PR DESCRIPTION
This will fix https://github.com/soto-project/soto/issues/623. It isn't obvious from the docs this should be the case but it fixes the endpoint prefix for a number of services
