### PR TITLE
Format endpoint arrays

### DIFF
--- a/Sources/SotoCodeGeneratorLib/Templates/api.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/api.swift
@@ -86,10 +86,18 @@ extension Templates {
                     apiVersion: "{{apiVersion}}",
                     endpoint: endpoint,
         {{#first(serviceEndpoints)}}
-                    serviceEndpoints: [{{#serviceEndpoints}}{{.}}{{^last()}}, {{/last()}}{{/serviceEndpoints}}],
+                    serviceEndpoints: [
+        {{#serviceEndpoints}}
+                        {{.}}{{^last()}}, {{/last()}}
+        {{/serviceEndpoints}}
+                    ],
         {{/first(serviceEndpoints)}}
         {{#first(partitionEndpoints)}}
-                    partitionEndpoints: [{{#partitionEndpoints}}{{.}}{{^last()}}, {{/last()}}{{/partitionEndpoints}}],
+                    partitionEndpoints: [
+        {{#partitionEndpoints}}
+                        {{.}}{{^last()}}, {{/last()}}
+        {{/partitionEndpoints}}
+                    ],
         {{/first(partitionEndpoints)}}
         {{#errorTypes}}
                     errorType: {{.}}.self,


### PR DESCRIPTION
Instead of having serviceEndpoints and partitionEndpoints on one line, add new line for each endpoint

```swift
serviceEndpoints: [
    "us-gov-east-1": "ram.us-gov-east-1.amazonaws.com",
    "us-gov-west-1": "ram.us-gov-west-1.amazonaws.com"
],
```
instead of 
```swift
serviceEndpoints: ["us-gov-east-1": "ram.us-gov-east-1.amazonaws.com", "us-gov-west-1": "ram.us-gov-west-1.amazonaws.com"],
```
