### PR TITLE
Remove region enum, replace with String

### DIFF
--- a/Sources/SotoCodeGeneratorLib/AwsService.swift
+++ b/Sources/SotoCodeGeneratorLib/AwsService.swift
@@ -125,7 +125,7 @@ struct AwsService {
             context["partitionEndpoints"] = self.getPartitionEndpoints()
                 .map { (partition: $0.key, endpoint: $0.value.endpoint, region: $0.value.region) }
                 .sorted { $0.partition < $1.partition }
-                .map { ".\($0.partition.toSwiftRegionEnumCase()): (endpoint: \"\($0.endpoint)\", region: .\($0.region.rawValue.toSwiftRegionEnumCase()))" }
+                .map { ".\($0.partition.toSwiftRegionEnumCase()): (endpoint: \"\($0.endpoint)\", region: .\($0.region.toSwiftRegionEnumCase()))" }
         }
 
         context["operations"] = operations.operations
@@ -475,12 +475,7 @@ struct AwsService {
             return value + (endpoints?.map { (key: $0.key, value: EndpointInfo(endpoint: $0.value, partition: partition.partition)) } ?? [])
         }
         let partitionEndpoints = self.getPartitionEndpoints()
-        let partitionEndpointSet = Set<String>(partitionEndpoints.map(\.value.endpoint))
         return serviceEndpoints.compactMap {
-            // if service endpoint isn't in the set of partition endpoints or a region name return nil
-            if partitionEndpointSet.contains($0.key) == false, Region(rawValue: $0.key) == nil {
-                return nil
-            }
             // if endpoint has a hostname return that
             if let hostname = $0.value.endpoint.hostname {
                 return (key: $0.key, value: hostname)
@@ -494,8 +489,8 @@ struct AwsService {
     }
 
     // return dictionary of partition endpoints keyed by endpoint name
-    func getPartitionEndpoints() -> [String: (endpoint: String, region: Region)] {
-        var partitionEndpoints: [String: (endpoint: String, region: Region)] = [:]
+    func getPartitionEndpoints() -> [String: (endpoint: String, region: String)] {
+        var partitionEndpoints: [String: (endpoint: String, region: String)] = [:]
         self.endpoints.partitions.forEach {
             guard let service = $0.services[self.serviceEndpointPrefix] else { return }
             guard let partitionEndpoint = service.partitionEndpoint else { return }

--- a/Sources/SotoCodeGeneratorLib/Endpoints.swift
+++ b/Sources/SotoCodeGeneratorLib/Endpoints.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Soto for AWS open source project
 //
-// Copyright (c) 2017-2020 the Soto project authors
+// Copyright (c) 2017-2022 the Soto project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -11,44 +11,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-
-enum Region: String, Decodable {
-    case useast1 = "us-east-1"
-    case useast2 = "us-east-2"
-    case uswest1 = "us-west-1"
-    case uswest2 = "us-west-2"
-    case apsouth1 = "ap-south-1"
-    case apsouth2 = "ap-south-2"
-    case apsoutheast1 = "ap-southeast-1"
-    case apnortheast2 = "ap-northeast-2"
-    case apnortheast3 = "ap-northeast-3"
-    case apnortheast1 = "ap-northeast-1"
-    case apsoutheast2 = "ap-southeast-2"
-    case apsoutheast3 = "ap-southeast-3"
-    case apeast1 = "ap-east-1"
-    case cacentral1 = "ca-central-1"
-    case euwest1 = "eu-west-1"
-    case euwest3 = "eu-west-3"
-    case euwest2 = "eu-west-2"
-    case eucentral1 = "eu-central-1"
-    case eucentral2 = "eu-central-2"
-    case eunorth1 = "eu-north-1"
-    case eusouth1 = "eu-south-1"
-    case eusouth2 = "eu-south-2"
-    case saeast1 = "sa-east-1"
-    case mecentral1 = "me-central-1"
-    case mesouth1 = "me-south-1"
-    case afsouth1 = "af-south-1"
-
-    case cnnorth1 = "cn-north-1"
-    case cnnorthwest1 = "cn-northwest-1"
-
-    case usgoveast1 = "us-gov-east-1"
-    case usgovwest1 = "us-gov-west-1"
-    case usisoeast1 = "us-iso-east-1"
-    case usisobeast1 = "us-isob-east-1"
-    case usisowest1 = "us-iso-west-1"
-}
 
 enum SignatureVersion: String, Decodable {
     case v2
@@ -59,7 +21,7 @@ enum SignatureVersion: String, Decodable {
 
 struct Endpoints: Decodable {
     struct CredentialScope: Decodable {
-        var region: Region?
+        var region: String?
         var service: String?
     }
 


### PR DESCRIPTION
This PR removes the region enum and replaces it with a string. Previously AWS introducing new regions would break the code generator. With this change it won't.

A side effect of this change is the [FIPS](https://aws.amazon.com/compliance/fips/) compliant endpoints are now included in the list of service endpoints. You can see this in PR https://github.com/soto-project/soto/pull/633 