### PR TITLE
Build plugin configuration file

### DIFF
--- a/Sources/SotoCodeGenerator/main.swift
+++ b/Sources/SotoCodeGenerator/main.swift
@@ -27,6 +27,9 @@ struct Command: ParsableCommand, SotoCodeGenCommand {
     @Option(name: .shortAndLong, help: "Input model file")
     var inputFile: String?
 
+    @Option(name: [.short, .customLong("config")], help: "Configuration file")
+    var configFile: String?
+
     @Option(name: .shortAndLong, help: "Prefix applied to output swift files")
     var prefix: String?
 

--- a/Sources/SotoCodeGeneratorLib/AwsService+paginators.swift
+++ b/Sources/SotoCodeGeneratorLib/AwsService+paginators.swift
@@ -18,7 +18,7 @@ import SotoSmithy
 extension AwsService {
     /// Generate paginator context
     func generatePaginatorContext() throws -> [String: Any] {
-        let paginatorOperations = try model.select(from: "operation [trait|paginated]")
+        let paginatorOperations = self.operations.filter { $0.value.hasTrait(type: PaginatedTrait.self) }
         guard paginatorOperations.count > 0 else { return [:] }
         var context: [String: Any] = ["name": serviceName]
         let namespace = paginatorOperations.first?.key.namespace
@@ -28,7 +28,7 @@ extension AwsService {
 
         // build list of operations that can be paginated
         for operation in paginatorOperations {
-            guard let operationShape = operation.value as? OperationShape else { continue }
+            let operationShape = operation.value
             guard let paginatedTrait = operationShape.trait(type: PaginatedTrait.self) else { continue }
             guard let input = operationShape.input?.target else { continue }
             guard let inputShape = model.shape(for: input) as? StructureShape else { continue }

--- a/Sources/SotoCodeGeneratorLib/AwsService+waiters.swift
+++ b/Sources/SotoCodeGeneratorLib/AwsService+waiters.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Soto for AWS open source project
 //
-// Copyright (c) 2017-2021 the Soto project authors
+// Copyright (c) 2017-2022 the Soto project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -21,7 +21,7 @@ extension AwsService {
         var context: [String: Any] = [:]
         context["name"] = self.serviceName
         var waiters: [WaiterContext] = []
-        for operation in operations {
+        for operation in self.operations {
             guard let trait = operation.value.trait(type: WaitableTrait.self) else { continue }
             for waiter in trait.value {
                 let waiterContext = try generateWaiterContext(

--- a/Sources/SotoCodeGeneratorLib/AwsService.swift
+++ b/Sources/SotoCodeGeneratorLib/AwsService.swift
@@ -26,7 +26,7 @@ struct AwsService {
     let service: ServiceShape
     let serviceProtocolTrait: AwsServiceProtocol
     let endpoints: Endpoints
-    let operations: [ShapeId: OperationShape]
+    var operations: [ShapeId: OperationShape]
     let outputHTMLComments: Bool
     let logger: Logger
 
@@ -132,6 +132,13 @@ struct AwsService {
         context["streamingOperations"] = operations.streamingOperations
         context["logger"] = self.getSymbol(for: "Logger", from: "Logging", model: self.model, namespace: serviceId.namespace ?? "")
         return context
+    }
+
+    /// filter operations list
+    mutating func filterOperations(_ filter: [String]) {
+        self.operations = self.operations.filter { key, _ in
+            return filter.contains(key.shapeName.toSwiftVariableCase())
+        }
     }
 
     /// Generate the context information for outputting the error enums

--- a/Sources/SotoCodeGeneratorLib/ConfigFile.swift
+++ b/Sources/SotoCodeGeneratorLib/ConfigFile.swift
@@ -17,6 +17,11 @@ struct ConfigFile: Decodable {
         let operations: [String]?
     }
 
-    let services: [String: ServiceConfig]
-    let `internal`: Bool?
+    enum AccessControl: String, Decodable {
+        case `public`
+        case `internal`
+    }
+
+    let services: [String: ServiceConfig]?
+    let access: AccessControl?
 }

--- a/Sources/SotoCodeGeneratorLib/ConfigFile.swift
+++ b/Sources/SotoCodeGeneratorLib/ConfigFile.swift
@@ -1,0 +1,22 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Soto for AWS open source project
+//
+// Copyright (c) 2017-2022 the Soto project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Soto project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+struct ConfigFile: Decodable {
+    struct ServiceConfig: Decodable {
+        let operations: [String]?
+    }
+
+    let services: [String: ServiceConfig]
+    let `internal`: Bool?
+}

--- a/Sources/SotoCodeGeneratorLib/SotoCodeGen.swift
+++ b/Sources/SotoCodeGeneratorLib/SotoCodeGen.swift
@@ -104,7 +104,7 @@ public struct SotoCodeGen {
                         .split(separator: "/", omittingEmptySubsequences: true).last!
                     let filenameWithoutExtension = String(filename[..<(filename.lastIndex(of: ".") ?? filename.endIndex)])
 
-                    if let serviceConfig = config.services[filenameWithoutExtension], let filter = serviceConfig.operations {
+                    if let serviceConfig = config.services?[filenameWithoutExtension], let filter = serviceConfig.operations {
                         service.filterOperations(filter)
                     }
                     if self.command.output {
@@ -156,7 +156,7 @@ public struct SotoCodeGen {
             let config = try JSONDecoder().decode(ConfigFile.self, from: configData)
             return config
         } else {
-            return .init(services: [:], internal: false)
+            return .init(services: [:], access: .public)
         }
     }
 
@@ -218,7 +218,7 @@ public struct SotoCodeGen {
             basePath = "\(self.command.outputFolder)"
             prefix = self.command.prefix.map { $0.replacingOccurrences(of: "-", with: "_") } ?? service.serviceName
         }
-        let scope = config.internal == true ? "internal" : "public"
+        let scope = config.access == .internal ? "internal" : "public"
 
         var apiContext = try service.generateServiceContext()
         let paginators = try service.generatePaginatorContext()

--- a/Sources/SotoCodeGeneratorLib/Templates/api+async.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/api+async.swift
@@ -36,7 +36,7 @@ extension Templates {
     {{#deprecated}}
         @available(*, deprecated, message:"{{.}}")
     {{/deprecated}}
-        public func {{funcName}}({{#inputShape}}_ input: {{.}}, {{/inputShape}}logger: {{logger}} = AWSClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws{{#outputShape}} -> {{.}}{{/outputShape}} {
+        {{scope}} func {{funcName}}({{#inputShape}}_ input: {{.}}, {{/inputShape}}logger: {{logger}} = AWSClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws{{#outputShape}} -> {{.}}{{/outputShape}} {
             return try await self.client.execute(operation: "{{name}}", path: "{{path}}", httpMethod: .{{httpMethod}}, serviceConfig: self.config{{#inputShape}}, input: input{{/inputShape}}{{#endpointRequired}}, endpointDiscovery: .init(storage: self.endpointStorage, discover: self.getEndpoint, required: {{required}}){{/endpointRequired}}{{#hostPrefix}}, hostPrefix: "{{{.}}}"{{/hostPrefix}}, logger: logger, on: eventLoop)
         }
     {{/operations}}
@@ -54,7 +54,7 @@ extension Templates {
     {{#deprecated}}
         @available(*, deprecated, message:"{{.}}")
     {{/deprecated}}
-        public func {{funcName}}Streaming({{#inputShape}}_ input: {{.}}, {{/inputShape}}logger: {{logger}} = AWSClient.loggingDisabled, on eventLoop: EventLoop? = nil, _ stream: @escaping ({{streaming}}, EventLoop) -> EventLoopFuture<Void>) async throws{{#outputShape}} -> {{.}}{{/outputShape}} {
+        {{scope}} func {{funcName}}Streaming({{#inputShape}}_ input: {{.}}, {{/inputShape}}logger: {{logger}} = AWSClient.loggingDisabled, on eventLoop: EventLoop? = nil, _ stream: @escaping ({{streaming}}, EventLoop) -> EventLoopFuture<Void>) async throws{{#outputShape}} -> {{.}}{{/outputShape}} {
             return try await self.client.execute(operation: "{{name}}", path: "{{path}}", httpMethod: .{{httpMethod}}, serviceConfig: self.config{{#inputShape}}, input: input{{/inputShape}}{{#endpointRequired}}, endpointDiscovery: .init(storage: self.endpointStorage, discover: self.getEndpoint, required: {{required}}){{/endpointRequired}}{{#hostPrefix}}, hostPrefix: "{{{.}}}"{{/hostPrefix}}, logger: logger, on: eventLoop, stream: stream)
         }
     {{/streamingOperations}}

--- a/Sources/SotoCodeGeneratorLib/Templates/api.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/api.swift
@@ -31,13 +31,13 @@ extension Templates {
         /// {{.}}
         {{/description}}
         {{/first(description)}}
-        public struct {{ name }}: AWSService {
+        {{scope}} struct {{ name }}: AWSService {
             // MARK: Member variables
 
             /// Client used for communication with AWS
-            public let client: AWSClient
+            {{scope}} let client: AWSClient
             /// Service configuration
-            public let config: AWSServiceConfig
+            {{scope}} let config: AWSServiceConfig
         {{#endpointDiscovery}}
             /// endpoint storage
             let endpointStorage: AWSEndpointStorage
@@ -54,7 +54,7 @@ extension Templates {
             ///     - partition: AWS partition where service resides, standard (.aws), china (.awscn), government (.awsusgov).
             ///     - endpoint: Custom endpoint URL to use instead of standard AWS servers
             ///     - timeout: Timeout value for HTTP requests
-            public init(
+            {{scope}} init(
                 client: AWSClient,
         {{#regionalized}}
                 region: SotoCore.Region? = nil,
@@ -129,7 +129,7 @@ extension Templates {
         {{#deprecated}}
             @available(*, deprecated, message:"{{.}}")
         {{/deprecated}}
-            {{^outputShape}}@discardableResult {{/outputShape}}public func {{funcName}}({{#inputShape}}_ input: {{.}}, {{/inputShape}}logger: {{logger}} = AWSClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<{{#outputShape}}{{.}}{{/outputShape}}{{^outputShape}}Void{{/outputShape}}> {
+            {{^outputShape}}@discardableResult {{/outputShape}}{{scope}} func {{funcName}}({{#inputShape}}_ input: {{.}}, {{/inputShape}}logger: {{logger}} = AWSClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<{{#outputShape}}{{.}}{{/outputShape}}{{^outputShape}}Void{{/outputShape}}> {
                 return self.client.execute(operation: "{{name}}", path: "{{path}}", httpMethod: .{{httpMethod}}, serviceConfig: self.config{{#inputShape}}, input: input{{/inputShape}}{{#endpointRequired}}, endpointDiscovery: .init(storage: self.endpointStorage, discover: self.getEndpoint, required: {{required}}){{/endpointRequired}}{{#hostPrefix}}, hostPrefix: "{{{.}}}"{{/hostPrefix}}, logger: logger, on: eventLoop)
             }
         {{/operations}}
@@ -147,7 +147,7 @@ extension Templates {
         {{#deprecated}}
             @available(*, deprecated, message:"{{.}}")
         {{/deprecated}}
-            {{^outputShape}}@discardableResult {{/outputShape}}public func {{funcName}}Streaming({{#inputShape}}_ input: {{.}}, {{/inputShape}}logger: {{logger}} = AWSClient.loggingDisabled, on eventLoop: EventLoop? = nil{{#streaming}}, _ stream: @escaping ({{.}}, EventLoop)->EventLoopFuture<Void>{{/streaming}}) -> EventLoopFuture<{{#outputShape}}{{.}}{{/outputShape}}{{^outputShape}}Void{{/outputShape}}> {
+            {{^outputShape}}@discardableResult {{/outputShape}}{{scope}} func {{funcName}}Streaming({{#inputShape}}_ input: {{.}}, {{/inputShape}}logger: {{logger}} = AWSClient.loggingDisabled, on eventLoop: EventLoop? = nil{{#streaming}}, _ stream: @escaping ({{.}}, EventLoop)->EventLoopFuture<Void>{{/streaming}}) -> EventLoopFuture<{{#outputShape}}{{.}}{{/outputShape}}{{^outputShape}}Void{{/outputShape}}> {
                 return self.client.execute(operation: "{{name}}", path: "{{path}}", httpMethod: .{{httpMethod}}, serviceConfig: self.config{{#inputShape}}, input: input{{/inputShape}}{{#endpointRequired}}, endpointDiscovery: .init(storage: self.endpointStorage, discover: self.getEndpoint, required: {{required}}){{/endpointRequired}}{{#hostPrefix}}, hostPrefix: "{{{.}}}"{{/hostPrefix}}, logger: logger, on: eventLoop{{#streaming}}, stream: stream{{/streaming}})
             }
         {{/streamingOperations}}
@@ -165,9 +165,9 @@ extension Templates {
         }
 
         extension {{ name }} {
-            /// Initializer required by `AWSService.with(middlewares:timeout:byteBufferAllocator:options)`. You are not able to use this initializer directly as there are no public
+            /// Initializer required by `AWSService.with(middlewares:timeout:byteBufferAllocator:options)`. You are not able to use this initializer directly as there are no {{scope}}
             /// initializers for `AWSServiceConfig.Patch`. Please use `AWSService.with(middlewares:timeout:byteBufferAllocator:options)` instead.
-            public init(from: {{ name }}, patch: AWSServiceConfig.Patch) {
+            {{scope}} init(from: {{ name }}, patch: AWSServiceConfig.Patch) {
                 self.client = from.client
                 self.config = from.config.with(patch: patch)
             {{#endpointDiscovery}}

--- a/Sources/SotoCodeGeneratorLib/Templates/enum.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/enum.swift
@@ -16,30 +16,30 @@ extension Templates {
     static let enumTemplate = """
     {{%CONTENT_TYPE:TEXT}}
     {{#isExtensible}}
-        public struct {{name}}: RawRepresentable, Equatable, Codable, _SotoSendable {
-            public var rawValue: String
+        {{scope}} struct {{name}}: RawRepresentable, Equatable, Codable, _SotoSendable {
+            {{scope}} var rawValue: String
 
-            public init(rawValue: String) {
+            {{scope}} init(rawValue: String) {
                 self.rawValue = rawValue
             }
     {{#values}}
     {{#documentation}}
             /// {{.}}
     {{/documentation}}
-            public static var {{case}}: Self { .init(rawValue: "{{string}}")}
+            {{scope}} static var {{case}}: Self { .init(rawValue: "{{string}}")}
     {{/values}}
         }
 
     {{/isExtensible}}
     {{^isExtensible}}
-        public enum {{name}}: String, CustomStringConvertible, Codable, _SotoSendable {
+        {{scope}} enum {{name}}: String, CustomStringConvertible, Codable, _SotoSendable {
     {{#values}}
     {{#documentation}}
             /// {{.}}
     {{/documentation}}
             case {{case}} = "{{string}}"
     {{/values}}
-            public var description: String { return self.rawValue }
+            {{scope}} var description: String { return self.rawValue }
         }
     {{/isExtensible}}
     """

--- a/Sources/SotoCodeGeneratorLib/Templates/enumWithValues.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/enumWithValues.swift
@@ -13,135 +13,135 @@
 //===----------------------------------------------------------------------===//
 
 extension Templates {
-    static let enumWithValuesTemplate = #"""
-    {{! Template for a AWSShape enum with values }}
-    {{%CONTENT_TYPE:TEXT}}
-        public {{object}} {{name}}: {{shapeProtocol}}, _SotoSendable {
-    {{#namespace}}
-            public static let _xmlNamespace: String? = "{{.}}"
-    {{/namespace}}
-    {{! AWSShapeMember array }}
-    {{#first(awsShapeMembers)}}
-            public static var _encoding = [
-    {{#awsShapeMembers}}
-                AWSMemberEncoding(label: "{{name}}"{{#location}}, location: {{.}}{{/location}}){{^last()}}, {{/last()}}
-    {{/awsShapeMembers}}
-            ]
+        static let enumWithValuesTemplate = #"""
+        {{! Template for a AWSShape enum with values }}
+        {{%CONTENT_TYPE:TEXT}}
+            {{scope}} {{object}} {{name}}: {{shapeProtocol}}, _SotoSendable {
+        {{#namespace}}
+                {{scope}} static let _xmlNamespace: String? = "{{.}}"
+        {{/namespace}}
+        {{! AWSShapeMember array }}
+        {{#first(awsShapeMembers)}}
+                {{scope}} static var _encoding = [
+        {{#awsShapeMembers}}
+                    AWSMemberEncoding(label: "{{name}}"{{#location}}, location: {{.}}{{/location}}){{^last()}}, {{/last()}}
+        {{/awsShapeMembers}}
+                ]
 
-    {{/first(awsShapeMembers)}}
-    {{! enum cases }}
-    {{#members}}
-    {{#comment}}
-            /// {{.}}
-    {{/comment}}
-            case {{variable}}({{type}})
-    {{/members}}
-    {{#isDecodable}}
+        {{/first(awsShapeMembers)}}
+        {{! enum cases }}
+        {{#members}}
+        {{#comment}}
+                /// {{.}}
+        {{/comment}}
+                case {{variable}}({{type}})
+        {{/members}}
+        {{#isDecodable}}
 
-            public init(from decoder: Decoder) throws {
-                let container = try decoder.container(keyedBy: CodingKeys.self)
-                guard container.allKeys.count == 1, let key = container.allKeys.first else {
-                    let context = DecodingError.Context(
-                        codingPath: container.codingPath,
-                        debugDescription: "Expected exactly one key, but got \(container.allKeys.count)"
-                    )
-                    throw DecodingError.dataCorrupted(context)
-                }
-                switch key {
-    {{#members}}
-                case .{{variable}}:
-                    let value = try container.decode({{type}}.self, forKey: .{{variable}})
-                    self = .{{variable}}(value)
-    {{/members}}
-                }
-            }
-    {{/isDecodable}}
-    {{#isEncodable}}
-
-            public func encode(to encoder: Encoder) throws {
-                var container = encoder.container(keyedBy: CodingKeys.self)
-                switch self {
-    {{#members}}
-                case .{{variable}}(let value):
-                    try container.encode(value, forKey: .{{variable}})
-    {{/members}}
-                }
-            }
-    {{/isEncodable}}
-
-    {{! validate() function }}
-    {{#first(validation)}}
-            public func validate(name: String) throws {
-                switch self {
-    {{#validation}}
-                case .{{name}}(let value):
-    {{#shape}}
-                    try value.validate(name: "\(name).{{name}}")
-    {{/shape}}
-    {{! validate array members }}
-    {{#.member}}
-                    try value.forEach {
-    {{#shape}}
-                        try $0.validate(name: "\(name).{{name}}[]")
-    {{/shape}}
-    {{#sorted(reqs)}}
-                        try validate($0, name: "{{name}}[]", parent: name, {{key}}: {{value}})
-    {{/sorted(reqs)}}
+                {{scope}} init(from decoder: Decoder) throws {
+                    let container = try decoder.container(keyedBy: CodingKeys.self)
+                    guard container.allKeys.count == 1, let key = container.allKeys.first else {
+                        let context = DecodingError.Context(
+                            codingPath: container.codingPath,
+                            debugDescription: "Expected exactly one key, but got \(container.allKeys.count)"
+                        )
+                        throw DecodingError.dataCorrupted(context)
                     }
-    {{/.member}}
-    {{! validate dictionary keys and possibly values }}
-    {{#withDictionaryContexts(.)}}
-                    try value.forEach {
-    {{#.keyValidation}}
-    {{#shape}}
-                        try $0.validate(name: "\(name).{{name}}.key")
-    {{/shape}}
-    {{#sorted(reqs)}}
-                        try validate($0.key, name: "{{name}}.key", parent: name, {{key}}: {{value}})
-    {{/sorted(reqs)}}
-    {{/.keyValidation}}
-    {{! validate dictionary values }}
-    {{#.valueValidation}}
-    {{#shape}}
-                        try $0.value.validate(name: "\(name).{{name}}[\"\($0.key)\"]")
-    {{/shape}}
-    {{#sorted(reqs)}}
-                        try validate($0.value, name: "{{name}}[\"\($0.key)\"]", parent: name, {{key}}: {{value}})
-    {{/sorted(reqs)}}
-    {{/.valueValidation}}
+                    switch key {
+        {{#members}}
+                    case .{{variable}}:
+                        let value = try container.decode({{type}}.self, forKey: .{{variable}})
+                        self = .{{variable}}(value)
+        {{/members}}
                     }
-    {{/withDictionaryContexts(.)}}
-    {{! validate min,max,pattern }}
-    {{#sorted(reqs)}}
-                    try validate(value, name: "{{name}}", parent: name, {{key}}: {{value}})
-    {{/sorted(reqs)}}
-    {{/validation}}
-    {{#requiresDefaultValidation}}
-                default:
-                    break
-    {{/requiresDefaultValidation}}
                 }
-            }
+        {{/isDecodable}}
+        {{#isEncodable}}
 
-    {{/first(validation)}}
-    {{! CodingKeys enum }}
-    {{#first(members)}}
-    {{^first(codingKeys)}}
-            private enum CodingKeys: CodingKey {}
-    {{/first(codingKeys)}}
-    {{#first(codingKeys)}}
-            private enum CodingKeys: String, CodingKey {
-    {{#codingKeys}}
-    {{#duplicate}}
-                case {{variable}} = "_{{codingKey}}" // TODO this is temporary measure for avoiding CodingKey duplication.
-    {{/duplicate}}
-    {{^duplicate}}
-                case {{variable}} = "{{codingKey}}"
-    {{/duplicate}}
-    {{/codingKeys}}
+                {{scope}} func encode(to encoder: Encoder) throws {
+                    var container = encoder.container(keyedBy: CodingKeys.self)
+                    switch self {
+        {{#members}}
+                    case .{{variable}}(let value):
+                        try container.encode(value, forKey: .{{variable}})
+        {{/members}}
+                    }
+                }
+        {{/isEncodable}}
+
+        {{! validate() function }}
+        {{#first(validation)}}
+                {{scope}} func validate(name: String) throws {
+                    switch self {
+        {{#validation}}
+                    case .{{name}}(let value):
+        {{#shape}}
+                        try value.validate(name: "\(name).{{name}}")
+        {{/shape}}
+        {{! validate array members }}
+        {{#.member}}
+                        try value.forEach {
+        {{#shape}}
+                            try $0.validate(name: "\(name).{{name}}[]")
+        {{/shape}}
+        {{#sorted(reqs)}}
+                            try validate($0, name: "{{name}}[]", parent: name, {{key}}: {{value}})
+        {{/sorted(reqs)}}
+                        }
+        {{/.member}}
+        {{! validate dictionary keys and possibly values }}
+        {{#withDictionaryContexts(.)}}
+                        try value.forEach {
+        {{#.keyValidation}}
+        {{#shape}}
+                            try $0.validate(name: "\(name).{{name}}.key")
+        {{/shape}}
+        {{#sorted(reqs)}}
+                            try validate($0.key, name: "{{name}}.key", parent: name, {{key}}: {{value}})
+        {{/sorted(reqs)}}
+        {{/.keyValidation}}
+        {{! validate dictionary values }}
+        {{#.valueValidation}}
+        {{#shape}}
+                            try $0.value.validate(name: "\(name).{{name}}[\"\($0.key)\"]")
+        {{/shape}}
+        {{#sorted(reqs)}}
+                            try validate($0.value, name: "{{name}}[\"\($0.key)\"]", parent: name, {{key}}: {{value}})
+        {{/sorted(reqs)}}
+        {{/.valueValidation}}
+                        }
+        {{/withDictionaryContexts(.)}}
+        {{! validate min,max,pattern }}
+        {{#sorted(reqs)}}
+                        try validate(value, name: "{{name}}", parent: name, {{key}}: {{value}})
+        {{/sorted(reqs)}}
+        {{/validation}}
+        {{#requiresDefaultValidation}}
+                    default:
+                        break
+        {{/requiresDefaultValidation}}
+                    }
+                }
+
+        {{/first(validation)}}
+        {{! CodingKeys enum }}
+        {{#first(members)}}
+        {{^first(codingKeys)}}
+                private enum CodingKeys: CodingKey {}
+        {{/first(codingKeys)}}
+        {{#first(codingKeys)}}
+                private enum CodingKeys: String, CodingKey {
+        {{#codingKeys}}
+        {{#duplicate}}
+                    case {{variable}} = "_{{codingKey}}" // TODO this is temporary measure for avoiding CodingKey duplication.
+        {{/duplicate}}
+        {{^duplicate}}
+                    case {{variable}} = "{{codingKey}}"
+        {{/duplicate}}
+        {{/codingKeys}}
+                }
+        {{/first(codingKeys)}}
+        {{/first(members)}}
             }
-    {{/first(codingKeys)}}
-    {{/first(members)}}
-        }
-    """#
+        """#
 }

--- a/Sources/SotoCodeGeneratorLib/Templates/enumWithValues.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/enumWithValues.swift
@@ -13,135 +13,135 @@
 //===----------------------------------------------------------------------===//
 
 extension Templates {
-        static let enumWithValuesTemplate = #"""
-        {{! Template for a AWSShape enum with values }}
-        {{%CONTENT_TYPE:TEXT}}
-            {{scope}} {{object}} {{name}}: {{shapeProtocol}}, _SotoSendable {
-        {{#namespace}}
-                {{scope}} static let _xmlNamespace: String? = "{{.}}"
-        {{/namespace}}
-        {{! AWSShapeMember array }}
-        {{#first(awsShapeMembers)}}
-                {{scope}} static var _encoding = [
-        {{#awsShapeMembers}}
-                    AWSMemberEncoding(label: "{{name}}"{{#location}}, location: {{.}}{{/location}}){{^last()}}, {{/last()}}
-        {{/awsShapeMembers}}
-                ]
+    static let enumWithValuesTemplate = #"""
+    {{! Template for a AWSShape enum with values }}
+    {{%CONTENT_TYPE:TEXT}}
+        {{scope}} {{object}} {{name}}: {{shapeProtocol}}, _SotoSendable {
+    {{#namespace}}
+            {{scope}} static let _xmlNamespace: String? = "{{.}}"
+    {{/namespace}}
+    {{! AWSShapeMember array }}
+    {{#first(awsShapeMembers)}}
+            {{scope}} static var _encoding = [
+    {{#awsShapeMembers}}
+                AWSMemberEncoding(label: "{{name}}"{{#location}}, location: {{.}}{{/location}}){{^last()}}, {{/last()}}
+    {{/awsShapeMembers}}
+            ]
 
-        {{/first(awsShapeMembers)}}
-        {{! enum cases }}
-        {{#members}}
-        {{#comment}}
-                /// {{.}}
-        {{/comment}}
-                case {{variable}}({{type}})
-        {{/members}}
-        {{#isDecodable}}
+    {{/first(awsShapeMembers)}}
+    {{! enum cases }}
+    {{#members}}
+    {{#comment}}
+            /// {{.}}
+    {{/comment}}
+            case {{variable}}({{type}})
+    {{/members}}
+    {{#isDecodable}}
 
-                {{scope}} init(from decoder: Decoder) throws {
-                    let container = try decoder.container(keyedBy: CodingKeys.self)
-                    guard container.allKeys.count == 1, let key = container.allKeys.first else {
-                        let context = DecodingError.Context(
-                            codingPath: container.codingPath,
-                            debugDescription: "Expected exactly one key, but got \(container.allKeys.count)"
-                        )
-                        throw DecodingError.dataCorrupted(context)
-                    }
-                    switch key {
-        {{#members}}
-                    case .{{variable}}:
-                        let value = try container.decode({{type}}.self, forKey: .{{variable}})
-                        self = .{{variable}}(value)
-        {{/members}}
-                    }
+            {{scope}} init(from decoder: Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                guard container.allKeys.count == 1, let key = container.allKeys.first else {
+                    let context = DecodingError.Context(
+                        codingPath: container.codingPath,
+                        debugDescription: "Expected exactly one key, but got \(container.allKeys.count)"
+                    )
+                    throw DecodingError.dataCorrupted(context)
                 }
-        {{/isDecodable}}
-        {{#isEncodable}}
-
-                {{scope}} func encode(to encoder: Encoder) throws {
-                    var container = encoder.container(keyedBy: CodingKeys.self)
-                    switch self {
-        {{#members}}
-                    case .{{variable}}(let value):
-                        try container.encode(value, forKey: .{{variable}})
-        {{/members}}
-                    }
+                switch key {
+    {{#members}}
+                case .{{variable}}:
+                    let value = try container.decode({{type}}.self, forKey: .{{variable}})
+                    self = .{{variable}}(value)
+    {{/members}}
                 }
-        {{/isEncodable}}
-
-        {{! validate() function }}
-        {{#first(validation)}}
-                {{scope}} func validate(name: String) throws {
-                    switch self {
-        {{#validation}}
-                    case .{{name}}(let value):
-        {{#shape}}
-                        try value.validate(name: "\(name).{{name}}")
-        {{/shape}}
-        {{! validate array members }}
-        {{#.member}}
-                        try value.forEach {
-        {{#shape}}
-                            try $0.validate(name: "\(name).{{name}}[]")
-        {{/shape}}
-        {{#sorted(reqs)}}
-                            try validate($0, name: "{{name}}[]", parent: name, {{key}}: {{value}})
-        {{/sorted(reqs)}}
-                        }
-        {{/.member}}
-        {{! validate dictionary keys and possibly values }}
-        {{#withDictionaryContexts(.)}}
-                        try value.forEach {
-        {{#.keyValidation}}
-        {{#shape}}
-                            try $0.validate(name: "\(name).{{name}}.key")
-        {{/shape}}
-        {{#sorted(reqs)}}
-                            try validate($0.key, name: "{{name}}.key", parent: name, {{key}}: {{value}})
-        {{/sorted(reqs)}}
-        {{/.keyValidation}}
-        {{! validate dictionary values }}
-        {{#.valueValidation}}
-        {{#shape}}
-                            try $0.value.validate(name: "\(name).{{name}}[\"\($0.key)\"]")
-        {{/shape}}
-        {{#sorted(reqs)}}
-                            try validate($0.value, name: "{{name}}[\"\($0.key)\"]", parent: name, {{key}}: {{value}})
-        {{/sorted(reqs)}}
-        {{/.valueValidation}}
-                        }
-        {{/withDictionaryContexts(.)}}
-        {{! validate min,max,pattern }}
-        {{#sorted(reqs)}}
-                        try validate(value, name: "{{name}}", parent: name, {{key}}: {{value}})
-        {{/sorted(reqs)}}
-        {{/validation}}
-        {{#requiresDefaultValidation}}
-                    default:
-                        break
-        {{/requiresDefaultValidation}}
-                    }
-                }
-
-        {{/first(validation)}}
-        {{! CodingKeys enum }}
-        {{#first(members)}}
-        {{^first(codingKeys)}}
-                private enum CodingKeys: CodingKey {}
-        {{/first(codingKeys)}}
-        {{#first(codingKeys)}}
-                private enum CodingKeys: String, CodingKey {
-        {{#codingKeys}}
-        {{#duplicate}}
-                    case {{variable}} = "_{{codingKey}}" // TODO this is temporary measure for avoiding CodingKey duplication.
-        {{/duplicate}}
-        {{^duplicate}}
-                    case {{variable}} = "{{codingKey}}"
-        {{/duplicate}}
-        {{/codingKeys}}
-                }
-        {{/first(codingKeys)}}
-        {{/first(members)}}
             }
-        """#
+    {{/isDecodable}}
+    {{#isEncodable}}
+
+            {{scope}} func encode(to encoder: Encoder) throws {
+                var container = encoder.container(keyedBy: CodingKeys.self)
+                switch self {
+    {{#members}}
+                case .{{variable}}(let value):
+                    try container.encode(value, forKey: .{{variable}})
+    {{/members}}
+                }
+            }
+    {{/isEncodable}}
+
+    {{! validate() function }}
+    {{#first(validation)}}
+            {{scope}} func validate(name: String) throws {
+                switch self {
+    {{#validation}}
+                case .{{name}}(let value):
+    {{#shape}}
+                    try value.validate(name: "\(name).{{name}}")
+    {{/shape}}
+    {{! validate array members }}
+    {{#.member}}
+                    try value.forEach {
+    {{#shape}}
+                        try $0.validate(name: "\(name).{{name}}[]")
+    {{/shape}}
+    {{#sorted(reqs)}}
+                        try validate($0, name: "{{name}}[]", parent: name, {{key}}: {{value}})
+    {{/sorted(reqs)}}
+                    }
+    {{/.member}}
+    {{! validate dictionary keys and possibly values }}
+    {{#withDictionaryContexts(.)}}
+                    try value.forEach {
+    {{#.keyValidation}}
+    {{#shape}}
+                        try $0.validate(name: "\(name).{{name}}.key")
+    {{/shape}}
+    {{#sorted(reqs)}}
+                        try validate($0.key, name: "{{name}}.key", parent: name, {{key}}: {{value}})
+    {{/sorted(reqs)}}
+    {{/.keyValidation}}
+    {{! validate dictionary values }}
+    {{#.valueValidation}}
+    {{#shape}}
+                        try $0.value.validate(name: "\(name).{{name}}[\"\($0.key)\"]")
+    {{/shape}}
+    {{#sorted(reqs)}}
+                        try validate($0.value, name: "{{name}}[\"\($0.key)\"]", parent: name, {{key}}: {{value}})
+    {{/sorted(reqs)}}
+    {{/.valueValidation}}
+                    }
+    {{/withDictionaryContexts(.)}}
+    {{! validate min,max,pattern }}
+    {{#sorted(reqs)}}
+                    try validate(value, name: "{{name}}", parent: name, {{key}}: {{value}})
+    {{/sorted(reqs)}}
+    {{/validation}}
+    {{#requiresDefaultValidation}}
+                default:
+                    break
+    {{/requiresDefaultValidation}}
+                }
+            }
+
+    {{/first(validation)}}
+    {{! CodingKeys enum }}
+    {{#first(members)}}
+    {{^first(codingKeys)}}
+            private enum CodingKeys: CodingKey {}
+    {{/first(codingKeys)}}
+    {{#first(codingKeys)}}
+            private enum CodingKeys: String, CodingKey {
+    {{#codingKeys}}
+    {{#duplicate}}
+                case {{variable}} = "_{{codingKey}}" // TODO this is temporary measure for avoiding CodingKey duplication.
+    {{/duplicate}}
+    {{^duplicate}}
+                case {{variable}} = "{{codingKey}}"
+    {{/duplicate}}
+    {{/codingKeys}}
+            }
+    {{/first(codingKeys)}}
+    {{/first(members)}}
+        }
+    """#
 }

--- a/Sources/SotoCodeGeneratorLib/Templates/error.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/error.swift
@@ -17,7 +17,7 @@ extension Templates {
     // MARK - Errors
 
     /// Error enum for {{name}}
-    public struct {{errorName}}: AWSErrorType {
+    {{scope}} struct {{errorName}}: AWSErrorType {
         enum Code: String {
     {{#errors}}
             case {{enum}} = "{{string}}"
@@ -25,10 +25,10 @@ extension Templates {
         }
 
         private let error: Code
-        public let context: AWSErrorContext?
+        {{scope}} let context: AWSErrorContext?
 
         /// initialize {{name}}
-        public init?(errorCode: String, context: AWSErrorContext) {
+        {{scope}} init?(errorCode: String, context: AWSErrorContext) {
             guard let error = Code(rawValue: errorCode) else { return nil }
             self.error = error
             self.context = context
@@ -40,24 +40,24 @@ extension Templates {
         }
 
         /// return error code string
-        public var errorCode: String { self.error.rawValue }
+        {{scope}} var errorCode: String { self.error.rawValue }
 
     {{#errors}}
     {{#comment}}
         /// {{.}}
     {{/comment}}
-        public static var {{enum}}: Self { .init(.{{enum}}) }
+        {{scope}} static var {{enum}}: Self { .init(.{{enum}}) }
     {{/errors}}
     }
 
     extension {{errorName}}: Equatable {
-        public static func == (lhs: {{errorName}}, rhs: {{errorName}}) -> Bool {
+        {{scope}} static func == (lhs: {{errorName}}, rhs: {{errorName}}) -> Bool {
             lhs.error == rhs.error
         }
     }
 
     extension {{errorName}}: CustomStringConvertible {
-        public var description: String {
+        {{scope}} var description: String {
             return "\(self.error.rawValue): \(self.message ?? "")"
         }
     }

--- a/Sources/SotoCodeGeneratorLib/Templates/paginators+async.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/paginators+async.swift
@@ -32,7 +32,7 @@ extension Templates {
     {{#operation.deprecated}}
         @available(*, deprecated, message:"{{.}}")
     {{/operation.deprecated}}
-        public func {{operation.funcName}}Paginator(
+        {{scope}} func {{operation.funcName}}Paginator(
             _ input: {{operation.inputShape}},
             logger: {{logger}} = AWSClient.loggingDisabled,
             on eventLoop: EventLoop? = nil

--- a/Sources/SotoCodeGeneratorLib/Templates/paginators.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/paginators.swift
@@ -36,7 +36,7 @@ extension Templates {
     {{#operation.deprecated}}
         @available(*, deprecated, message:"{{.}}")
     {{/operation.deprecated}}
-        public func {{operation.funcName}}Paginator<Result>(
+        {{scope}} func {{operation.funcName}}Paginator<Result>(
             _ input: {{operation.inputShape}},
             _ initialValue: Result,
             logger: {{logger}} = AWSClient.loggingDisabled,
@@ -72,7 +72,7 @@ extension Templates {
     {{#operation.deprecated}}
         @available(*, deprecated, message:"{{.}}")
     {{/operation.deprecated}}
-        public func {{operation.funcName}}Paginator(
+        {{scope}} func {{operation.funcName}}Paginator(
             _ input: {{operation.inputShape}},
             logger: {{logger}} = AWSClient.loggingDisabled,
             on eventLoop: EventLoop? = nil,
@@ -103,7 +103,7 @@ extension Templates {
 
     {{#paginatorShapes}}
     extension {{name}}.{{inputShape}}: {{paginatorProtocol}} {
-        public func usingPaginationToken(_ token: {{tokenType}}) -> {{name}}.{{inputShape}} {
+        {{scope}} func usingPaginationToken(_ token: {{tokenType}}) -> {{name}}.{{inputShape}} {
             return .init(
     {{#initParams}}
                 {{.}}{{^last()}},{{/last()}}

--- a/Sources/SotoCodeGeneratorLib/Templates/struct.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/struct.swift
@@ -13,136 +13,136 @@
 //===----------------------------------------------------------------------===//
 
 extension Templates {
-    static let structTemplate = #"""
-    {{%CONTENT_TYPE:TEXT}}
-    {{! Template for a AWSShape }}
-        public {{object}} {{name}}: {{shapeProtocol}} {
-    {{#payload}}
-            /// The key for the payload
-            public static let _payloadPath: String = "{{.}}"
-    {{/payload}}
-    {{#options}}
-            public static let _options: AWSShapeOptions = [{{.}}]
-    {{/options}}
-    {{#namespace}}
-            public static let _xmlNamespace: String? = "{{.}}"
-    {{/namespace}}
-    {{! AWSShapeMember array }}
-    {{#first(awsShapeMembers)}}
-            public static var _encoding = [
-    {{#awsShapeMembers}}
-                AWSMemberEncoding(label: "{{name}}"{{#location}}, location: {{.}}{{/location}}){{^last()}}, {{/last()}}
-    {{/awsShapeMembers}}
-            ]
-    {{/first(awsShapeMembers)}}
-    {{#encoding}}
-    {{! Is encoding a dictionary }}
-    {{#key}}
-            public struct {{name}}: DictionaryCoderProperties { static public let entry: String? = {{#entry}}"{{.}}"{{/entry}}{{^entry}}nil{{/entry}}; static public let key = "{{key}}"; static public let value = "{{value}}" }
-    {{/key}}
-    {{^key}}
-            public struct {{name}}: ArrayCoderProperties { static public let member = "{{member}}" }
-    {{/key}}
-    {{/encoding}}
+        static let structTemplate = #"""
+        {{%CONTENT_TYPE:TEXT}}
+        {{! Template for a AWSShape }}
+            {{scope}} {{object}} {{name}}: {{shapeProtocol}} {
+        {{#payload}}
+                /// The key for the payload
+                {{scope}} static let _payloadPath: String = "{{.}}"
+        {{/payload}}
+        {{#options}}
+                {{scope}} static let _options: AWSShapeOptions = [{{.}}]
+        {{/options}}
+        {{#namespace}}
+                {{scope}} static let _xmlNamespace: String? = "{{.}}"
+        {{/namespace}}
+        {{! AWSShapeMember array }}
+        {{#first(awsShapeMembers)}}
+                {{scope}} static var _encoding = [
+        {{#awsShapeMembers}}
+                    AWSMemberEncoding(label: "{{name}}"{{#location}}, location: {{.}}{{/location}}){{^last()}}, {{/last()}}
+        {{/awsShapeMembers}}
+                ]
+        {{/first(awsShapeMembers)}}
+        {{#encoding}}
+        {{! Is encoding a dictionary }}
+        {{#key}}
+                {{scope}} struct {{name}}: DictionaryCoderProperties { static {{scope}} let entry: String? = {{#entry}}"{{.}}"{{/entry}}{{^entry}}nil{{/entry}}; static {{scope}} let key = "{{key}}"; static {{scope}} let value = "{{value}}" }
+        {{/key}}
+        {{^key}}
+                {{scope}} struct {{name}}: ArrayCoderProperties { static {{scope}} let member = "{{member}}" }
+        {{/key}}
+        {{/encoding}}
 
-    {{! Member variables }}
-    {{#members}}
-    {{#comment}}
-            /// {{.}}
-    {{/comment}}
-    {{#propertyWrapper}}
-            {{.}}
-    {{/propertyWrapper}}
-            public {{#propertyWrapper}}var{{/propertyWrapper}}{{^propertyWrapper}}let{{/propertyWrapper}} {{variable}}: {{type}}
-    {{/members}}
+        {{! Member variables }}
+        {{#members}}
+        {{#comment}}
+                /// {{.}}
+        {{/comment}}
+        {{#propertyWrapper}}
+                {{.}}
+        {{/propertyWrapper}}
+                {{scope}} {{#propertyWrapper}}var{{/propertyWrapper}}{{^propertyWrapper}}let{{/propertyWrapper}} {{variable}}: {{type}}
+        {{/members}}
 
-    {{! init() function }}
-            public init({{#initParameters}}{{parameter}}: {{type}}{{#default}} = {{.}}{{/default}}{{^last()}}, {{/last()}}{{/initParameters}}) {
-    {{#members}}
-    {{^deprecated}}
-                self.{{variable}} = {{variable}}
-    {{/deprecated}}
-    {{#deprecated}}
-                self.{{variable}} = {{default}}
-    {{/deprecated}}
-    {{/members}}
-            }
-    {{! deprecated init() function }}
-    {{^empty(deprecatedMembers)}}
-            @available(*, deprecated, message:"Members {{#deprecatedMembers}}{{.}}{{^last()}}, {{/last()}}{{/deprecatedMembers}} have been deprecated")
-            public init({{#members}}{{parameter}}: {{type}}{{#default}} = {{.}}{{/default}}{{^last()}}, {{/last()}}{{/members}}) {
-    {{#members}}
-                self.{{variable}} = {{variable}}
-    {{/members}}
-            }
-    {{/empty(deprecatedMembers)}}
-    {{! validate() function }}
-    {{#first(validation)}}
-
-            public func validate(name: String) throws {
-    {{#validation}}
-    {{#shape}}
-                try self.{{name}}{{^required}}?{{/required}}.validate(name: "\(name).{{name}}")
-    {{/shape}}
-    {{! validate array members }}
-    {{#.member}}
-                try self.{{name}}{{^required}}?{{/required}}.forEach {
-    {{#shape}}
-                    try $0.validate(name: "\(name).{{name}}[]")
-    {{/shape}}
-    {{#sorted(reqs)}}
-                    try validate($0, name: "{{name}}[]", parent: name, {{.key}}: {{.value}})
-    {{/sorted(reqs)}}
+        {{! init() function }}
+                {{scope}} init({{#initParameters}}{{parameter}}: {{type}}{{#default}} = {{.}}{{/default}}{{^last()}}, {{/last()}}{{/initParameters}}) {
+        {{#members}}
+        {{^deprecated}}
+                    self.{{variable}} = {{variable}}
+        {{/deprecated}}
+        {{#deprecated}}
+                    self.{{variable}} = {{default}}
+        {{/deprecated}}
+        {{/members}}
                 }
-    {{/.member}}
-    {{! validate dictionary members }}
-    {{#withDictionaryContexts(.)}}
-                try self.{{name}}{{^required}}?{{/required}}.forEach {
-    {{#.keyValidation}}
-    {{#shape}}
-                    try $0.key.validate(name: "\(name).{{name}}.key")
-    {{/shape}}
-    {{#sorted(reqs)}}
-                    try validate($0.key, name: "{{name}}.key", parent: name, {{.key}}: {{.value}})
-    {{/sorted(reqs)}}
-    {{/.keyValidation}}
-    {{! validate dictionary values }}
-    {{#.valueValidation}}
-    {{#shape}}
-                    try $0.value.validate(name: "\(name).{{name}}[\"\($0.key)\"]")
-    {{/shape}}
-    {{#sorted(reqs)}}
-                    try validate($0.value, name: "{{name}}[\"\($0.key)\"]", parent: name, {{.key}}: {{.value}})
-    {{/sorted(reqs)}}
-    {{/.valueValidation}}
+        {{! deprecated init() function }}
+        {{^empty(deprecatedMembers)}}
+                @available(*, deprecated, message:"Members {{#deprecatedMembers}}{{.}}{{^last()}}, {{/last()}}{{/deprecatedMembers}} have been deprecated")
+                {{scope}} init({{#members}}{{parameter}}: {{type}}{{#default}} = {{.}}{{/default}}{{^last()}}, {{/last()}}{{/members}}) {
+        {{#members}}
+                    self.{{variable}} = {{variable}}
+        {{/members}}
                 }
-    {{/withDictionaryContexts(.)}}
-    {{! validate min,max,pattern }}
-    {{#sorted(reqs)}}
-                try self.validate(self.{{name}}, name: "{{name}}", parent: name, {{.key}}: {{.value}})
-    {{/sorted(reqs)}}
-    {{/validation}}
-            }
-    {{/first(validation)}}
+        {{/empty(deprecatedMembers)}}
+        {{! validate() function }}
+        {{#first(validation)}}
 
-    {{! CodingKeys enum }}
-    {{#first(members)}}
-    {{^first(codingKeys)}}
-            private enum CodingKeys: CodingKey {}
-    {{/first(codingKeys)}}
-    {{#first(codingKeys)}}
-            private enum CodingKeys: String, CodingKey {
-    {{#codingKeys}}
-    {{#duplicate}}
-                case {{variable}} = "_{{codingKey}}" // TODO this is temporary measure for avoiding CodingKey duplication.
-    {{/duplicate}}
-    {{^duplicate}}
-                case {{variable}} = "{{codingKey}}"
-    {{/duplicate}}
-    {{/codingKeys}}
+                {{scope}} func validate(name: String) throws {
+        {{#validation}}
+        {{#shape}}
+                    try self.{{name}}{{^required}}?{{/required}}.validate(name: "\(name).{{name}}")
+        {{/shape}}
+        {{! validate array members }}
+        {{#.member}}
+                    try self.{{name}}{{^required}}?{{/required}}.forEach {
+        {{#shape}}
+                        try $0.validate(name: "\(name).{{name}}[]")
+        {{/shape}}
+        {{#sorted(reqs)}}
+                        try validate($0, name: "{{name}}[]", parent: name, {{.key}}: {{.value}})
+        {{/sorted(reqs)}}
+                    }
+        {{/.member}}
+        {{! validate dictionary members }}
+        {{#withDictionaryContexts(.)}}
+                    try self.{{name}}{{^required}}?{{/required}}.forEach {
+        {{#.keyValidation}}
+        {{#shape}}
+                        try $0.key.validate(name: "\(name).{{name}}.key")
+        {{/shape}}
+        {{#sorted(reqs)}}
+                        try validate($0.key, name: "{{name}}.key", parent: name, {{.key}}: {{.value}})
+        {{/sorted(reqs)}}
+        {{/.keyValidation}}
+        {{! validate dictionary values }}
+        {{#.valueValidation}}
+        {{#shape}}
+                        try $0.value.validate(name: "\(name).{{name}}[\"\($0.key)\"]")
+        {{/shape}}
+        {{#sorted(reqs)}}
+                        try validate($0.value, name: "{{name}}[\"\($0.key)\"]", parent: name, {{.key}}: {{.value}})
+        {{/sorted(reqs)}}
+        {{/.valueValidation}}
+                    }
+        {{/withDictionaryContexts(.)}}
+        {{! validate min,max,pattern }}
+        {{#sorted(reqs)}}
+                    try self.validate(self.{{name}}, name: "{{name}}", parent: name, {{.key}}: {{.value}})
+        {{/sorted(reqs)}}
+        {{/validation}}
+                }
+        {{/first(validation)}}
+
+        {{! CodingKeys enum }}
+        {{#first(members)}}
+        {{^first(codingKeys)}}
+                private enum CodingKeys: CodingKey {}
+        {{/first(codingKeys)}}
+        {{#first(codingKeys)}}
+                private enum CodingKeys: String, CodingKey {
+        {{#codingKeys}}
+        {{#duplicate}}
+                    case {{variable}} = "_{{codingKey}}" // TODO this is temporary measure for avoiding CodingKey duplication.
+        {{/duplicate}}
+        {{^duplicate}}
+                    case {{variable}} = "{{codingKey}}"
+        {{/duplicate}}
+        {{/codingKeys}}
+                }
+        {{/first(codingKeys)}}
+        {{/first(members)}}
             }
-    {{/first(codingKeys)}}
-    {{/first(members)}}
-        }
-    """#
+        """#
 }

--- a/Sources/SotoCodeGeneratorLib/Templates/struct.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/struct.swift
@@ -13,136 +13,136 @@
 //===----------------------------------------------------------------------===//
 
 extension Templates {
-        static let structTemplate = #"""
-        {{%CONTENT_TYPE:TEXT}}
-        {{! Template for a AWSShape }}
-            {{scope}} {{object}} {{name}}: {{shapeProtocol}} {
-        {{#payload}}
-                /// The key for the payload
-                {{scope}} static let _payloadPath: String = "{{.}}"
-        {{/payload}}
-        {{#options}}
-                {{scope}} static let _options: AWSShapeOptions = [{{.}}]
-        {{/options}}
-        {{#namespace}}
-                {{scope}} static let _xmlNamespace: String? = "{{.}}"
-        {{/namespace}}
-        {{! AWSShapeMember array }}
-        {{#first(awsShapeMembers)}}
-                {{scope}} static var _encoding = [
-        {{#awsShapeMembers}}
-                    AWSMemberEncoding(label: "{{name}}"{{#location}}, location: {{.}}{{/location}}){{^last()}}, {{/last()}}
-        {{/awsShapeMembers}}
-                ]
-        {{/first(awsShapeMembers)}}
-        {{#encoding}}
-        {{! Is encoding a dictionary }}
-        {{#key}}
-                {{scope}} struct {{name}}: DictionaryCoderProperties { static {{scope}} let entry: String? = {{#entry}}"{{.}}"{{/entry}}{{^entry}}nil{{/entry}}; static {{scope}} let key = "{{key}}"; static {{scope}} let value = "{{value}}" }
-        {{/key}}
-        {{^key}}
-                {{scope}} struct {{name}}: ArrayCoderProperties { static {{scope}} let member = "{{member}}" }
-        {{/key}}
-        {{/encoding}}
+    static let structTemplate = #"""
+    {{%CONTENT_TYPE:TEXT}}
+    {{! Template for a AWSShape }}
+        {{scope}} {{object}} {{name}}: {{shapeProtocol}} {
+    {{#payload}}
+            /// The key for the payload
+            {{scope}} static let _payloadPath: String = "{{.}}"
+    {{/payload}}
+    {{#options}}
+            {{scope}} static let _options: AWSShapeOptions = [{{.}}]
+    {{/options}}
+    {{#namespace}}
+            {{scope}} static let _xmlNamespace: String? = "{{.}}"
+    {{/namespace}}
+    {{! AWSShapeMember array }}
+    {{#first(awsShapeMembers)}}
+            {{scope}} static var _encoding = [
+    {{#awsShapeMembers}}
+                AWSMemberEncoding(label: "{{name}}"{{#location}}, location: {{.}}{{/location}}){{^last()}}, {{/last()}}
+    {{/awsShapeMembers}}
+            ]
+    {{/first(awsShapeMembers)}}
+    {{#encoding}}
+    {{! Is encoding a dictionary }}
+    {{#key}}
+            {{scope}} struct {{name}}: DictionaryCoderProperties { static {{scope}} let entry: String? = {{#entry}}"{{.}}"{{/entry}}{{^entry}}nil{{/entry}}; static {{scope}} let key = "{{key}}"; static {{scope}} let value = "{{value}}" }
+    {{/key}}
+    {{^key}}
+            {{scope}} struct {{name}}: ArrayCoderProperties { static {{scope}} let member = "{{member}}" }
+    {{/key}}
+    {{/encoding}}
 
-        {{! Member variables }}
-        {{#members}}
-        {{#comment}}
-                /// {{.}}
-        {{/comment}}
-        {{#propertyWrapper}}
-                {{.}}
-        {{/propertyWrapper}}
-                {{scope}} {{#propertyWrapper}}var{{/propertyWrapper}}{{^propertyWrapper}}let{{/propertyWrapper}} {{variable}}: {{type}}
-        {{/members}}
+    {{! Member variables }}
+    {{#members}}
+    {{#comment}}
+            /// {{.}}
+    {{/comment}}
+    {{#propertyWrapper}}
+            {{.}}
+    {{/propertyWrapper}}
+            {{scope}} {{#propertyWrapper}}var{{/propertyWrapper}}{{^propertyWrapper}}let{{/propertyWrapper}} {{variable}}: {{type}}
+    {{/members}}
 
-        {{! init() function }}
-                {{scope}} init({{#initParameters}}{{parameter}}: {{type}}{{#default}} = {{.}}{{/default}}{{^last()}}, {{/last()}}{{/initParameters}}) {
-        {{#members}}
-        {{^deprecated}}
-                    self.{{variable}} = {{variable}}
-        {{/deprecated}}
-        {{#deprecated}}
-                    self.{{variable}} = {{default}}
-        {{/deprecated}}
-        {{/members}}
-                }
-        {{! deprecated init() function }}
-        {{^empty(deprecatedMembers)}}
-                @available(*, deprecated, message:"Members {{#deprecatedMembers}}{{.}}{{^last()}}, {{/last()}}{{/deprecatedMembers}} have been deprecated")
-                {{scope}} init({{#members}}{{parameter}}: {{type}}{{#default}} = {{.}}{{/default}}{{^last()}}, {{/last()}}{{/members}}) {
-        {{#members}}
-                    self.{{variable}} = {{variable}}
-        {{/members}}
-                }
-        {{/empty(deprecatedMembers)}}
-        {{! validate() function }}
-        {{#first(validation)}}
-
-                {{scope}} func validate(name: String) throws {
-        {{#validation}}
-        {{#shape}}
-                    try self.{{name}}{{^required}}?{{/required}}.validate(name: "\(name).{{name}}")
-        {{/shape}}
-        {{! validate array members }}
-        {{#.member}}
-                    try self.{{name}}{{^required}}?{{/required}}.forEach {
-        {{#shape}}
-                        try $0.validate(name: "\(name).{{name}}[]")
-        {{/shape}}
-        {{#sorted(reqs)}}
-                        try validate($0, name: "{{name}}[]", parent: name, {{.key}}: {{.value}})
-        {{/sorted(reqs)}}
-                    }
-        {{/.member}}
-        {{! validate dictionary members }}
-        {{#withDictionaryContexts(.)}}
-                    try self.{{name}}{{^required}}?{{/required}}.forEach {
-        {{#.keyValidation}}
-        {{#shape}}
-                        try $0.key.validate(name: "\(name).{{name}}.key")
-        {{/shape}}
-        {{#sorted(reqs)}}
-                        try validate($0.key, name: "{{name}}.key", parent: name, {{.key}}: {{.value}})
-        {{/sorted(reqs)}}
-        {{/.keyValidation}}
-        {{! validate dictionary values }}
-        {{#.valueValidation}}
-        {{#shape}}
-                        try $0.value.validate(name: "\(name).{{name}}[\"\($0.key)\"]")
-        {{/shape}}
-        {{#sorted(reqs)}}
-                        try validate($0.value, name: "{{name}}[\"\($0.key)\"]", parent: name, {{.key}}: {{.value}})
-        {{/sorted(reqs)}}
-        {{/.valueValidation}}
-                    }
-        {{/withDictionaryContexts(.)}}
-        {{! validate min,max,pattern }}
-        {{#sorted(reqs)}}
-                    try self.validate(self.{{name}}, name: "{{name}}", parent: name, {{.key}}: {{.value}})
-        {{/sorted(reqs)}}
-        {{/validation}}
-                }
-        {{/first(validation)}}
-
-        {{! CodingKeys enum }}
-        {{#first(members)}}
-        {{^first(codingKeys)}}
-                private enum CodingKeys: CodingKey {}
-        {{/first(codingKeys)}}
-        {{#first(codingKeys)}}
-                private enum CodingKeys: String, CodingKey {
-        {{#codingKeys}}
-        {{#duplicate}}
-                    case {{variable}} = "_{{codingKey}}" // TODO this is temporary measure for avoiding CodingKey duplication.
-        {{/duplicate}}
-        {{^duplicate}}
-                    case {{variable}} = "{{codingKey}}"
-        {{/duplicate}}
-        {{/codingKeys}}
-                }
-        {{/first(codingKeys)}}
-        {{/first(members)}}
+    {{! init() function }}
+            {{scope}} init({{#initParameters}}{{parameter}}: {{type}}{{#default}} = {{.}}{{/default}}{{^last()}}, {{/last()}}{{/initParameters}}) {
+    {{#members}}
+    {{^deprecated}}
+                self.{{variable}} = {{variable}}
+    {{/deprecated}}
+    {{#deprecated}}
+                self.{{variable}} = {{default}}
+    {{/deprecated}}
+    {{/members}}
             }
-        """#
+    {{! deprecated init() function }}
+    {{^empty(deprecatedMembers)}}
+            @available(*, deprecated, message:"Members {{#deprecatedMembers}}{{.}}{{^last()}}, {{/last()}}{{/deprecatedMembers}} have been deprecated")
+            {{scope}} init({{#members}}{{parameter}}: {{type}}{{#default}} = {{.}}{{/default}}{{^last()}}, {{/last()}}{{/members}}) {
+    {{#members}}
+                self.{{variable}} = {{variable}}
+    {{/members}}
+            }
+    {{/empty(deprecatedMembers)}}
+    {{! validate() function }}
+    {{#first(validation)}}
+
+            {{scope}} func validate(name: String) throws {
+    {{#validation}}
+    {{#shape}}
+                try self.{{name}}{{^required}}?{{/required}}.validate(name: "\(name).{{name}}")
+    {{/shape}}
+    {{! validate array members }}
+    {{#.member}}
+                try self.{{name}}{{^required}}?{{/required}}.forEach {
+    {{#shape}}
+                    try $0.validate(name: "\(name).{{name}}[]")
+    {{/shape}}
+    {{#sorted(reqs)}}
+                    try validate($0, name: "{{name}}[]", parent: name, {{.key}}: {{.value}})
+    {{/sorted(reqs)}}
+                }
+    {{/.member}}
+    {{! validate dictionary members }}
+    {{#withDictionaryContexts(.)}}
+                try self.{{name}}{{^required}}?{{/required}}.forEach {
+    {{#.keyValidation}}
+    {{#shape}}
+                    try $0.key.validate(name: "\(name).{{name}}.key")
+    {{/shape}}
+    {{#sorted(reqs)}}
+                    try validate($0.key, name: "{{name}}.key", parent: name, {{.key}}: {{.value}})
+    {{/sorted(reqs)}}
+    {{/.keyValidation}}
+    {{! validate dictionary values }}
+    {{#.valueValidation}}
+    {{#shape}}
+                    try $0.value.validate(name: "\(name).{{name}}[\"\($0.key)\"]")
+    {{/shape}}
+    {{#sorted(reqs)}}
+                    try validate($0.value, name: "{{name}}[\"\($0.key)\"]", parent: name, {{.key}}: {{.value}})
+    {{/sorted(reqs)}}
+    {{/.valueValidation}}
+                }
+    {{/withDictionaryContexts(.)}}
+    {{! validate min,max,pattern }}
+    {{#sorted(reqs)}}
+                try self.validate(self.{{name}}, name: "{{name}}", parent: name, {{.key}}: {{.value}})
+    {{/sorted(reqs)}}
+    {{/validation}}
+            }
+    {{/first(validation)}}
+
+    {{! CodingKeys enum }}
+    {{#first(members)}}
+    {{^first(codingKeys)}}
+            private enum CodingKeys: CodingKey {}
+    {{/first(codingKeys)}}
+    {{#first(codingKeys)}}
+            private enum CodingKeys: String, CodingKey {
+    {{#codingKeys}}
+    {{#duplicate}}
+                case {{variable}} = "_{{codingKey}}" // TODO this is temporary measure for avoiding CodingKey duplication.
+    {{/duplicate}}
+    {{^duplicate}}
+                case {{variable}} = "{{codingKey}}"
+    {{/duplicate}}
+    {{/codingKeys}}
+            }
+    {{/first(codingKeys)}}
+    {{/first(members)}}
+        }
+    """#
 }

--- a/Sources/SotoCodeGeneratorLib/Templates/waiters+async.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/waiters+async.swift
@@ -20,7 +20,7 @@ extension Templates {
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     extension {{name}} {
     {{#waiters}}
-        public func waitUntil{{waiterName}}(
+        {{scope}} func waitUntil{{waiterName}}(
             _ input: {{operation.inputShape}},
             maxWaitTime: TimeAmount? = nil,
             logger: Logger = AWSClient.loggingDisabled,

--- a/Sources/SotoCodeGeneratorLib/Templates/waiters.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/waiters.swift
@@ -25,7 +25,7 @@ extension Templates {
     {{#deprecated}}
         @available(*, deprecated)
     {{/deprecated}}
-        public func waitUntil{{waiterName}}(
+        {{scope}} func waitUntil{{waiterName}}(
             _ input: {{operation.inputShape}},
             maxWaitTime: TimeAmount? = nil,
             logger: Logger = AWSClient.loggingDisabled,


### PR DESCRIPTION
This adds a configuration file `soto.config.json` to the build plugin (PR #58) to control its output. It allows you to control what operations you output code for and whether they should be generated as internal to the module or public. Both of these can be used to reduce the amount of code linked into your application when using a service.

The config file is configured as follows
```json
{
    "services": { 
        "sns": {
            "operations": ["createTopic", "deleteTopic", "listTopics"]
        }
    },
    "access": "internal"
}
```
- The `services` field is a dictionary of service names (same name as service file). The value field of the dictionary is a type with only one field `operations`. This is an array of the operations you want generated code for. If you do not supply an operations field then code for all operations are output.
- The `access` field is an enum which can be either `public` or `internal`. If you do not supply this field it will default to `public`.
