### PR TITLE
Add support for generating variant endpoint array

### DIFF
--- a/Sources/SotoCodeGeneratorLib/AwsService.swift
+++ b/Sources/SotoCodeGeneratorLib/AwsService.swift
@@ -539,7 +539,7 @@ struct AwsService {
                 if let defaults = service.defaults {
                     endpointValue = endpointValue.applyingDefaults(defaults)
                 }
-                endpointValue = endpointValue.applyingGlobalDefaults(partition.defaults)
+                endpointValue = endpointValue.applyingPartitionDefaults(partition.defaults)
                 guard let variants = endpointValue.variants else { return }
                 variants.forEach { variant in
                     let variantString = variant.tags

--- a/Sources/SotoCodeGeneratorLib/AwsService.swift
+++ b/Sources/SotoCodeGeneratorLib/AwsService.swift
@@ -477,7 +477,7 @@ struct AwsService {
     func getServiceEndpoints() -> [(key: String, value: String)] {
         // create dictionary of endpoint name to Endpoint and partition from across all partitions
         struct EndpointInfo {
-            let endpoint: Endpoints.Service.Endpoint
+            let endpoint: Endpoints.Endpoint
             let partition: String
         }
         let serviceEndpoints: [(key: String, value: EndpointInfo)] = self.endpoints.partitions.reduce([]) { value, partition in

--- a/Sources/SotoCodeGeneratorLib/AwsService.swift
+++ b/Sources/SotoCodeGeneratorLib/AwsService.swift
@@ -539,6 +539,7 @@ struct AwsService {
                 if let defaults = service.defaults {
                     endpointValue = endpointValue.applyingDefaults(defaults)
                 }
+                endpointValue = endpointValue.applyingGlobalDefaults(partition.defaults)
                 guard let variants = endpointValue.variants else { return }
                 variants.forEach { variant in
                     let variantString = variant.tags

--- a/Sources/SotoCodeGeneratorLib/Endpoints.swift
+++ b/Sources/SotoCodeGeneratorLib/Endpoints.swift
@@ -39,6 +39,7 @@ struct Endpoints: Decodable {
         var variants: [EndpointVariant]?
         var deprecated: Bool?
 
+        // apply service defaults to endpoint
         func applyingDefaults(_ defaults: Defaults) -> Endpoint {
             return .init(
                 credentialScope: self.credentialScope ?? defaults.credentialScope,
@@ -50,7 +51,10 @@ struct Endpoints: Decodable {
             )
         }
 
-        func applyingGlobalDefaults(_ defaults: Defaults) -> Endpoint {
+        /// apply partition defaults to endpoint. This is slightly different to the service defaults
+        /// as it only applies variant endpoint data if there already exists variant endpoint data in
+        /// the endpoint.
+        func applyingPartitionDefaults(_ defaults: Defaults) -> Endpoint {
             var variants = self.variants
             if variants != nil {
                 variants = variants!.map { variant in

--- a/Sources/SotoCodeGeneratorLib/Endpoints.swift
+++ b/Sources/SotoCodeGeneratorLib/Endpoints.swift
@@ -38,6 +38,17 @@ struct Endpoints: Decodable {
         var signatureVersions: [SignatureVersion]?
         var variants: [EndpointVariant]?
         var deprecated: Bool?
+
+        func applyingDefaults(_ defaults: Defaults) -> Endpoint {
+            return .init(
+                credentialScope: self.credentialScope ?? defaults.credentialScope,
+                hostname: self.hostname ?? defaults.hostname,
+                protocols: self.protocols ?? defaults.protocols,
+                signatureVersions: self.signatureVersions ?? defaults.signatureVersions,
+                variants: self.variants ?? defaults.variants,
+                deprecated: self.deprecated
+            )
+        }
     }
 
     struct Defaults: Decodable {

--- a/Sources/SotoCodeGeneratorLib/Endpoints.swift
+++ b/Sources/SotoCodeGeneratorLib/Endpoints.swift
@@ -25,13 +25,13 @@ struct Endpoints: Decodable {
         var service: String?
     }
 
-    struct Endpoint: Decodable {
-        struct EndpointVariant: Decodable {
-            var dnsSuffix: String?
-            var hostname: String?
-            var tags: [String]
-        }
+    struct EndpointVariant: Decodable {
+        var dnsSuffix: String?
+        var hostname: String?
+        var tags: Set<String>
+    }
 
+    struct Endpoint: Decodable {
         var credentialScope: CredentialScope?
         var hostname: String?
         var protocols: [String]?
@@ -41,11 +41,11 @@ struct Endpoints: Decodable {
     }
 
     struct Defaults: Decodable {
-        var defaults: Endpoint?
         var credentialScope: CredentialScope?
         var hostname: String?
         var protocols: [String]?
         var signatureVersions: [SignatureVersion]?
+        var variants: [EndpointVariant]?
     }
 
     struct RegionDesc: Decodable {
@@ -53,7 +53,7 @@ struct Endpoints: Decodable {
     }
 
     struct Service: Decodable {
-        var defaults: Endpoint?
+        var defaults: Defaults?
         var endpoints: [String: Endpoint]
         var isRegionalized: Bool?
         var partitionEndpoint: String?

--- a/Sources/SotoCodeGeneratorLib/Endpoints.swift
+++ b/Sources/SotoCodeGeneratorLib/Endpoints.swift
@@ -25,7 +25,23 @@ struct Endpoints: Decodable {
         var service: String?
     }
 
+    struct Endpoint: Decodable {
+        struct EndpointVariant: Decodable {
+            var dnsSuffix: String?
+            var hostname: String?
+            var tags: [String]
+        }
+
+        var credentialScope: CredentialScope?
+        var hostname: String?
+        var protocols: [String]?
+        var signatureVersions: [SignatureVersion]?
+        var variants: [EndpointVariant]?
+        var deprecated: Bool?
+    }
+
     struct Defaults: Decodable {
+        var defaults: Endpoint?
         var credentialScope: CredentialScope?
         var hostname: String?
         var protocols: [String]?
@@ -37,13 +53,6 @@ struct Endpoints: Decodable {
     }
 
     struct Service: Decodable {
-        struct Endpoint: Decodable {
-            var credentialScope: CredentialScope?
-            var hostname: String?
-            var protocols: [String]?
-            var signatureVersions: [SignatureVersion]?
-        }
-
         var defaults: Endpoint?
         var endpoints: [String: Endpoint]
         var isRegionalized: Bool?

--- a/Sources/SotoCodeGeneratorLib/Endpoints.swift
+++ b/Sources/SotoCodeGeneratorLib/Endpoints.swift
@@ -49,6 +49,27 @@ struct Endpoints: Decodable {
                 deprecated: self.deprecated
             )
         }
+
+        func applyingGlobalDefaults(_ defaults: Defaults) -> Endpoint {
+            var variants = self.variants
+            if variants != nil {
+                variants = variants!.map { variant in
+                    if variant.hostname == nil {
+                        let hostname = defaults.variants?.first(where: { $0.tags == variant.tags })?.hostname
+                        return .init(dnsSuffix: variant.dnsSuffix, hostname: hostname, tags: variant.tags)
+                    }
+                    return variant
+                }
+            }
+            return .init(
+                credentialScope: self.credentialScope ?? defaults.credentialScope,
+                hostname: self.hostname ?? defaults.hostname,
+                protocols: self.protocols ?? defaults.protocols,
+                signatureVersions: self.signatureVersions ?? defaults.signatureVersions,
+                variants: variants,
+                deprecated: self.deprecated
+            )
+        }
     }
 
     struct Defaults: Decodable {

--- a/Sources/SotoCodeGeneratorLib/Templates/api.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/api.swift
@@ -99,6 +99,17 @@ extension Templates {
         {{/partitionEndpoints}}
                     ],
         {{/first(partitionEndpoints)}}
+        {{#first(variantEndpoints)}}
+                    variantEndpoints: [
+        {{#variantEndpoints}}
+                        [{{variant}}]: .init(endpoints: [
+        {{#endpoints.endpoints}}
+                            "{{region}}": "{{hostname}}"{{^last()}}, {{/last()}}
+        {{/endpoints.endpoints}}
+                        ]){{^last()}}, {{/last()}}
+        {{/variantEndpoints}}
+                    ],
+        {{/first(variantEndpoints)}}
         {{#errorTypes}}
                     errorType: {{.}}.self,
         {{/errorTypes}}


### PR DESCRIPTION
Extract variant endpoint data from `endpoints.json` and add `variantEndpoint` dictionary to `AWSServiceConfig` init.

Other changes include removing deprecated endpoints as they are replaced by the variant endpoints 