### PR TITLE
Add patch for Textract.TypeValue enum

### DIFF
--- a/Sources/SotoCodeGeneratorLib/Model+Patch.swift
+++ b/Sources/SotoCodeGeneratorLib/Model+Patch.swift
@@ -161,6 +161,9 @@ extension Model {
             // service name change
             "com.amazonaws.savingsplans#AWSSavingsPlan": EditTraitPatch { trait -> AwsServiceTrait in trait.with(sdkId: "SavingsPlans") },
         ],
+        "Textract": [
+            "com.amazonaws.textract#ValueType$Date": EditTraitPatch { _ in EnumValueTrait(value: .string("Date")) },
+        ]
     ]
     func patch(serviceName: String) throws {
         if let servicePatches = Self.patches[serviceName] {

--- a/Sources/SotoCodeGeneratorLib/Model+Patch.swift
+++ b/Sources/SotoCodeGeneratorLib/Model+Patch.swift
@@ -162,7 +162,7 @@ extension Model {
             "com.amazonaws.savingsplans#AWSSavingsPlan": EditTraitPatch { trait -> AwsServiceTrait in trait.with(sdkId: "SavingsPlans") },
         ],
         "Textract": [
-            "com.amazonaws.textract#ValueType$Date": EditTraitPatch { _ in EnumValueTrait(value: .string("Date")) },
+            "com.amazonaws.textract#ValueType$DATE": EditTraitPatch { _ in EnumValueTrait(value: .string("Date")) },
         ]
     ]
     func patch(serviceName: String) throws {


### PR DESCRIPTION
# What's new
Added a patch for `Textract.TypeValue` that sets the enum case from `DATE` to `Date`. 
This fixes an issue where response from an analyzeID request would fail to parse. Discussed here https://github.com/soto-project/soto/issues/656.

I have tested the generator and it does indeed generate a correct model.
```swift
public enum ValueType: String, CustomStringConvertible, Codable, _SotoSendable {
     case date = "Date"
     public var description: String { return self.rawValue }
}
```

@adam-fowler I imagine we need to also tag and update the `soto-codegenerator` dependecies on the main soto package.