### PR TITLE
Remove swift format dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/soto-project/soto-smithy.git", from: "0.3.1"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.0.0"),
-        .package(url: "https://github.com/hummingbird-project/hummingbird-mustache.git", from: "1.0.0"),
+        .package(url: "https://github.com/hummingbird-project/hummingbird-mustache.git", from: "1.0.3"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.4.0"),
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,6 @@ let package = Package(
         .package(url: "https://github.com/soto-project/soto-smithy.git", from: "0.3.1"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.0.0"),
         .package(url: "https://github.com/hummingbird-project/hummingbird-mustache.git", from: "1.0.0"),
-        .package(url: "https://github.com/nicklockwood/SwiftFormat.git", from: "0.48.17"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.4.0"),
     ],
     targets: [
@@ -29,7 +28,6 @@ let package = Package(
                 .product(name: "SotoSmithy", package: "soto-smithy"),
                 .product(name: "SotoSmithyAWS", package: "soto-smithy"),
                 .product(name: "HummingbirdMustache", package: "hummingbird-mustache"),
-                .product(name: "SwiftFormat", package: "SwiftFormat"),
                 .product(name: "Logging", package: "swift-log")
             ]
         ),

--- a/Package@swift-5.4.swift
+++ b/Package@swift-5.4.swift
@@ -10,7 +10,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/soto-project/soto-smithy.git", from: "0.3.1"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.0.0"),
-        .package(url: "https://github.com/hummingbird-project/hummingbird-mustache.git", from: "1.0.0"),
+        .package(url: "https://github.com/hummingbird-project/hummingbird-mustache.git", from: "1.0.3"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.4.0"),
     ],
     targets: [

--- a/Package@swift-5.4.swift
+++ b/Package@swift-5.4.swift
@@ -11,7 +11,6 @@ let package = Package(
         .package(url: "https://github.com/soto-project/soto-smithy.git", from: "0.3.1"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.0.0"),
         .package(url: "https://github.com/hummingbird-project/hummingbird-mustache.git", from: "1.0.0"),
-        .package(url: "https://github.com/nicklockwood/SwiftFormat.git", .exact("0.48.17")),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.4.0"),
     ],
     targets: [
@@ -29,7 +28,6 @@ let package = Package(
                 .product(name: "SotoSmithy", package: "soto-smithy"),
                 .product(name: "SotoSmithyAWS", package: "soto-smithy"),
                 .product(name: "HummingbirdMustache", package: "hummingbird-mustache"),
-                .product(name: "SwiftFormat", package: "SwiftFormat"),
                 .product(name: "Logging", package: "swift-log")
             ]
         ),

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -10,7 +10,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/soto-project/soto-smithy.git", from: "0.3.1"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.0.0"),
-        .package(url: "https://github.com/hummingbird-project/hummingbird-mustache.git", from: "1.0.0"),
+        .package(url: "https://github.com/hummingbird-project/hummingbird-mustache.git", from: "1.0.3"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.4.0"),
     ],
     targets: [

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -11,7 +11,6 @@ let package = Package(
         .package(url: "https://github.com/soto-project/soto-smithy.git", from: "0.3.1"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.0.0"),
         .package(url: "https://github.com/hummingbird-project/hummingbird-mustache.git", from: "1.0.0"),
-        .package(url: "https://github.com/nicklockwood/SwiftFormat.git", .exact("0.48.17")),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.4.0"),
     ],
     targets: [
@@ -29,7 +28,6 @@ let package = Package(
                 .product(name: "SotoSmithy", package: "soto-smithy"),
                 .product(name: "SotoSmithyAWS", package: "soto-smithy"),
                 .product(name: "HummingbirdMustache", package: "hummingbird-mustache"),
-                .product(name: "SwiftFormat", package: "SwiftFormat"),
                 .product(name: "Logging", package: "swift-log")
             ]
         ),

--- a/Sources/SotoCodeGenerator/main.swift
+++ b/Sources/SotoCodeGenerator/main.swift
@@ -42,9 +42,6 @@ struct Command: ParsableCommand, SotoCodeGenCommand {
     @Flag(name: .long, inversion: .prefixedNo, help: "Output files")
     var output: Bool = true
 
-    @Flag(name: [.customShort("f"), .customLong("format")], inversion: .prefixedNo, help: "Run swift format on output")
-    var swiftFormat: Bool = false
-
     @Flag(name: .long, help: "HTML comments")
     var htmlComments: Bool = false
 

--- a/Sources/SotoCodeGeneratorLib/AwsService+shapes.swift
+++ b/Sources/SotoCodeGeneratorLib/AwsService+shapes.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Soto for AWS open source project
 //
-// Copyright (c) 2017-2022 the Soto project authors
+// Copyright (c) 2017-2023 the Soto project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Sources/SotoCodeGeneratorLib/AwsService+shapes.swift
+++ b/Sources/SotoCodeGeneratorLib/AwsService+shapes.swift
@@ -370,11 +370,19 @@ extension AwsService {
         else {
             return nil
         }
-        var codingKey: String = name
+        var rawValue: String? = name
         if let aliasTrait = member.traits?.first(where: { $0 is AliasTrait }) as? AliasTrait {
-            codingKey = aliasTrait.alias
+            rawValue = aliasTrait.alias
         }
-        return CodingKeysContext(variable: name.toSwiftVariableCase(), codingKey: codingKey, duplicate: false)
+        let variable = name.toSwiftVariableCase()
+        if rawValue == variable {
+            // rawValue = nil
+        }
+        return CodingKeysContext(
+            variable: variable,
+            rawValue: rawValue,
+            duplicate: false
+        )
     }
 
     /// Generate array/dictionary encoding contexts

--- a/Sources/SotoCodeGeneratorLib/AwsService+shapes.swift
+++ b/Sources/SotoCodeGeneratorLib/AwsService+shapes.swift
@@ -376,7 +376,7 @@ extension AwsService {
         }
         let variable = name.toSwiftVariableCase()
         if rawValue == variable {
-            // rawValue = nil
+            rawValue = nil
         }
         return CodingKeysContext(
             variable: variable,

--- a/Sources/SotoCodeGeneratorLib/AwsService.swift
+++ b/Sources/SotoCodeGeneratorLib/AwsService.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Soto for AWS open source project
 //
-// Copyright (c) 2017-2022 the Soto project authors
+// Copyright (c) 2017-2023 the Soto project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Sources/SotoCodeGeneratorLib/AwsService.swift
+++ b/Sources/SotoCodeGeneratorLib/AwsService.swift
@@ -674,7 +674,7 @@ extension AwsService {
     struct EnumMemberContext {
         let `case`: String
         let documentation: [String.SubSequence]
-        let string: String
+        let rawValue: String?
     }
 
     struct ArrayEncodingPropertiesContext: EncodingPropertiesContext {

--- a/Sources/SotoCodeGeneratorLib/AwsService.swift
+++ b/Sources/SotoCodeGeneratorLib/AwsService.swift
@@ -674,7 +674,7 @@ extension AwsService {
     struct EnumMemberContext {
         let `case`: String
         let documentation: [String.SubSequence]
-        let rawValue: String?
+        let rawValue: String
     }
 
     struct ArrayEncodingPropertiesContext: EncodingPropertiesContext {
@@ -754,7 +754,7 @@ extension AwsService {
 
     struct CodingKeysContext {
         let variable: String
-        let rawValue: String?
+        let rawValue: String
         var duplicate: Bool
     }
 

--- a/Sources/SotoCodeGeneratorLib/AwsService.swift
+++ b/Sources/SotoCodeGeneratorLib/AwsService.swift
@@ -300,8 +300,8 @@ struct AwsService {
     }
 
     /// process documenation string
-    func processDocs(from shape: Shape) -> [String.SubSequence] {
-        var docs: [String.SubSequence]
+    func processDocs(from shape: Shape) -> [Substring] {
+        var docs: [Substring]
 
         let documentation = shape.trait(type: DocumentationTrait.self)?.value
         if self.outputHTMLComments {
@@ -311,7 +311,8 @@ struct AwsService {
                 .tagStriped()
                 .replacingOccurrences(of: "\n +", with: " ", options: .regularExpression, range: nil)
                 .split(separator: "\n")
-                .compactMap { $0.isEmpty ? nil : $0 } ?? []
+                .compactMap { $0.isEmpty ? nil : $0 }
+                .map { $0.dropLast(while: { $0.isWhitespace }) } ?? []
         }
 
         if let externalDocumentation = shape.trait(type: ExternalDocumentationTrait.self)?.value {
@@ -323,7 +324,7 @@ struct AwsService {
     }
 
     /// process documenation string
-    func processMemberDocs(from shape: MemberShape) -> [String.SubSequence] {
+    func processMemberDocs(from shape: MemberShape) -> [Substring] {
         guard var documentation = shape.trait(type: DocumentationTrait.self)?.value else { return [] }
         if let recommendation = shape.trait(type: RecommendedTrait.self)?.reason {
             documentation += "\n\(recommendation)"
@@ -333,6 +334,7 @@ struct AwsService {
             .replacingOccurrences(of: "\n +", with: " ", options: .regularExpression, range: nil)
             .split(separator: "\n")
             .compactMap { $0.isEmpty ? nil : $0 }
+            .map { $0.dropLast(while: { $0.isWhitespace }) }
     }
 
     /// process documentation string
@@ -752,7 +754,7 @@ extension AwsService {
 
     struct CodingKeysContext {
         let variable: String
-        let codingKey: String
+        let rawValue: String?
         var duplicate: Bool
     }
 

--- a/Sources/SotoCodeGeneratorLib/String.swift
+++ b/Sources/SotoCodeGeneratorLib/String.swift
@@ -162,6 +162,19 @@ extension StringProtocol {
         return true
     }
 
+    func dropLast(while: (Self.Element) throws -> Bool) rethrows -> Self.SubSequence {
+        var position = self.endIndex
+        var count = 0
+        while position != self.startIndex {
+            position = self.index(before: position)
+            if try !`while`(self[position]) {
+                break
+            }
+            count += 1
+        }
+        return self.dropLast(count)
+    }
+
     private func lowerFirst() -> String {
         return String(self[startIndex]).lowercased() + self[index(after: startIndex)...]
     }

--- a/Sources/SotoCodeGeneratorLib/Templates/Templates.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/Templates.swift
@@ -18,6 +18,7 @@ enum Templates {
     static var values: [String: String] = [
         "api": apiTemplate,
         "api_async": apiAsyncTemplate,
+        "comment": commentTemplate,
         "enum": enumTemplate,
         "enumWithValues": enumWithValuesTemplate,
         "errors": errorTemplate,

--- a/Sources/SotoCodeGeneratorLib/Templates/Templates.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/Templates.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Soto for AWS open source project
 //
-// Copyright (c) 2017-2021 the Soto project authors
+// Copyright (c) 2017-2023 the Soto project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Sources/SotoCodeGeneratorLib/Templates/api+async.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/api+async.swift
@@ -51,7 +51,7 @@ extension Templates {
         /// {{.}}
     {{/documentationUrl}}
     {{#deprecated}}
-        @available(*, deprecated, message:"{{.}}")
+        @available(*, deprecated, message: "{{.}}")
     {{/deprecated}}
         {{scope}} func {{funcName}}Streaming({{#inputShape}}_ input: {{.}}, {{/inputShape}}logger: {{logger}} = AWSClient.loggingDisabled, on eventLoop: EventLoop? = nil, _ stream: @escaping ({{streaming}}, EventLoop) -> EventLoopFuture<Void>) async throws{{#outputShape}} -> {{.}}{{/outputShape}} {
             return try await self.client.execute(operation: "{{name}}", path: "{{path}}", httpMethod: .{{httpMethod}}, serviceConfig: self.config{{#inputShape}}, input: input{{/inputShape}}{{#endpointRequired}}, endpointDiscovery: .init(storage: self.endpointStorage, discover: self.getEndpoint, required: {{required}}){{/endpointRequired}}{{#hostPrefix}}, hostPrefix: "{{{.}}}"{{/hostPrefix}}, logger: logger, on: eventLoop, stream: stream)

--- a/Sources/SotoCodeGeneratorLib/Templates/api+async.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/api+async.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Soto for AWS open source project
 //
-// Copyright (c) 2017-2021 the Soto project authors
+// Copyright (c) 2017-2023 the Soto project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Sources/SotoCodeGeneratorLib/Templates/api+async.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/api+async.swift
@@ -23,7 +23,6 @@ extension Templates {
 
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     extension {{ name }} {
-
         // MARK: Async API Calls
     {{#operations}}
 
@@ -60,15 +59,16 @@ extension Templates {
     {{/streamingOperations}}
     {{/first(streamingOperations)}}
     }
-
     {{#paginators}}
+
     {{>paginators_async}}
     {{/paginators}}
-
     {{#waiters}}
+
     {{>waiters_async}}
     {{/waiters}}
 
     #endif // compiler(>=5.5.2) && canImport(_Concurrency)
+
     """
 }

--- a/Sources/SotoCodeGeneratorLib/Templates/api+async.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/api+async.swift
@@ -27,13 +27,13 @@ extension Templates {
     {{#operations}}
 
     {{#comment}}
-        /// {{.}}
+        {{>comment}}
     {{/comment}}
     {{#documentationUrl}}
         /// {{.}}
     {{/documentationUrl}}
     {{#deprecated}}
-        @available(*, deprecated, message:"{{.}}")
+        @available(*, deprecated, message: "{{.}}")
     {{/deprecated}}
         {{scope}} func {{funcName}}({{#inputShape}}_ input: {{.}}, {{/inputShape}}logger: {{logger}} = AWSClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws{{#outputShape}} -> {{.}}{{/outputShape}} {
             return try await self.client.execute(operation: "{{name}}", path: "{{path}}", httpMethod: .{{httpMethod}}, serviceConfig: self.config{{#inputShape}}, input: input{{/inputShape}}{{#endpointRequired}}, endpointDiscovery: .init(storage: self.endpointStorage, discover: self.getEndpoint, required: {{required}}){{/endpointRequired}}{{#hostPrefix}}, hostPrefix: "{{{.}}}"{{/hostPrefix}}, logger: logger, on: eventLoop)
@@ -45,7 +45,7 @@ extension Templates {
     {{#streamingOperations}}
 
     {{#comment}}
-        /// {{.}}
+        {{>comment}}
     {{/comment}}
     {{#documentationUrl}}
         /// {{.}}

--- a/Sources/SotoCodeGeneratorLib/Templates/api.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/api.swift
@@ -88,14 +88,14 @@ extension Templates {
         {{#first(serviceEndpoints)}}
                     serviceEndpoints: [
         {{#serviceEndpoints}}
-                        {{.}}{{^last()}}, {{/last()}}
+                        {{.}}{{^last()}},{{/last()}}
         {{/serviceEndpoints}}
                     ],
         {{/first(serviceEndpoints)}}
         {{#first(partitionEndpoints)}}
                     partitionEndpoints: [
         {{#partitionEndpoints}}
-                        {{.}}{{^last()}}, {{/last()}}
+                        {{.}}{{^last()}},{{/last()}}
         {{/partitionEndpoints}}
                     ],
         {{/first(partitionEndpoints)}}
@@ -104,9 +104,9 @@ extension Templates {
         {{#variantEndpoints}}
                         [{{variant}}]: .init(endpoints: [
         {{#endpoints.endpoints}}
-                            "{{region}}": "{{hostname}}"{{^last()}}, {{/last()}}
+                            "{{region}}": "{{hostname}}"{{^last()}},{{/last()}}
         {{/endpoints.endpoints}}
-                        ]){{^last()}}, {{/last()}}
+                        ]){{^last()}},{{/last()}}
         {{/variantEndpoints}}
                     ],
         {{/first(variantEndpoints)}}
@@ -186,12 +186,12 @@ extension Templates {
             {{/endpointDiscovery}}
             }
         }
-
         {{#paginators}}
+
         {{>paginators}}
         {{/paginators}}
-
         {{#waiters}}
+
         {{>waiters}}
         {{/waiters}}
         """#

--- a/Sources/SotoCodeGeneratorLib/Templates/api.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/api.swift
@@ -124,7 +124,7 @@ extension Templates {
                     options: options
                 )
                 {{#endpointDiscovery}}
-                    self.endpointStorage = .init(endpoint: self.config.endpoint)
+                self.endpointStorage = .init(endpoint: self.config.endpoint)
                 {{/endpointDiscovery}}
             }
 
@@ -166,7 +166,7 @@ extension Templates {
         {{#endpointDiscovery}}
 
             func getEndpoint(logger: Logger, eventLoop: EventLoop) -> EventLoopFuture<AWSEndpoints> {
-                return describeEndpoints(.init(), logger: logger, on: eventLoop).map {
+                return self.describeEndpoints(.init(), logger: logger, on: eventLoop).map {
                     .init(endpoints: $0.endpoints.map {
                         .init(address: "https://\($0.address)", cachePeriodInMinutes: $0.cachePeriodInMinutes)
                     })

--- a/Sources/SotoCodeGeneratorLib/Templates/api.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/api.swift
@@ -138,7 +138,7 @@ extension Templates {
             /// {{.}}
         {{/documentationUrl}}
         {{#deprecated}}
-            @available(*, deprecated, message:"{{.}}")
+            @available(*, deprecated, message: "{{.}}")
         {{/deprecated}}
             {{^outputShape}}@discardableResult {{/outputShape}}{{scope}} func {{funcName}}({{#inputShape}}_ input: {{.}}, {{/inputShape}}logger: {{logger}} = AWSClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<{{#outputShape}}{{.}}{{/outputShape}}{{^outputShape}}Void{{/outputShape}}> {
                 return self.client.execute(operation: "{{name}}", path: "{{path}}", httpMethod: .{{httpMethod}}, serviceConfig: self.config{{#inputShape}}, input: input{{/inputShape}}{{#endpointRequired}}, endpointDiscovery: .init(storage: self.endpointStorage, discover: self.getEndpoint, required: {{required}}){{/endpointRequired}}{{#hostPrefix}}, hostPrefix: "{{{.}}}"{{/hostPrefix}}, logger: logger, on: eventLoop)

--- a/Sources/SotoCodeGeneratorLib/Templates/api.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/api.swift
@@ -28,7 +28,7 @@ extension Templates {
         {{#first(description)}}
         ///
         {{#description}}
-        /// {{.}}
+        {{>comment}}
         {{/description}}
         {{/first(description)}}
         {{scope}} struct {{ name }}: AWSService {
@@ -132,7 +132,7 @@ extension Templates {
         {{#operations}}
 
         {{#comment}}
-            /// {{.}}
+            {{>comment}}
         {{/comment}}
         {{#documentationUrl}}
             /// {{.}}
@@ -150,13 +150,13 @@ extension Templates {
         {{#streamingOperations}}
 
         {{#comment}}
-            /// {{.}}
+            {{>comment}}
         {{/comment}}
         {{#documentationUrl}}
             /// {{.}}
         {{/documentationUrl}}
         {{#deprecated}}
-            @available(*, deprecated, message:"{{.}}")
+            @available(*, deprecated, message: "{{.}}")
         {{/deprecated}}
             {{^outputShape}}@discardableResult {{/outputShape}}{{scope}} func {{funcName}}Streaming({{#inputShape}}_ input: {{.}}, {{/inputShape}}logger: {{logger}} = AWSClient.loggingDisabled, on eventLoop: EventLoop? = nil{{#streaming}}, _ stream: @escaping ({{.}}, EventLoop)->EventLoopFuture<Void>{{/streaming}}) -> EventLoopFuture<{{#outputShape}}{{.}}{{/outputShape}}{{^outputShape}}Void{{/outputShape}}> {
                 return self.client.execute(operation: "{{name}}", path: "{{path}}", httpMethod: .{{httpMethod}}, serviceConfig: self.config{{#inputShape}}, input: input{{/inputShape}}{{#endpointRequired}}, endpointDiscovery: .init(storage: self.endpointStorage, discover: self.getEndpoint, required: {{required}}){{/endpointRequired}}{{#hostPrefix}}, hostPrefix: "{{{.}}}"{{/hostPrefix}}, logger: logger, on: eventLoop{{#streaming}}, stream: stream{{/streaming}})
@@ -194,5 +194,6 @@ extension Templates {
 
         {{>waiters}}
         {{/waiters}}
+
         """#
 }

--- a/Sources/SotoCodeGeneratorLib/Templates/api.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/api.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Soto for AWS open source project
 //
-// Copyright (c) 2017-2021 the Soto project authors
+// Copyright (c) 2017-2023 the Soto project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Sources/SotoCodeGeneratorLib/Templates/api.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/api.swift
@@ -158,7 +158,7 @@ extension Templates {
         {{#deprecated}}
             @available(*, deprecated, message: "{{.}}")
         {{/deprecated}}
-            {{^outputShape}}@discardableResult {{/outputShape}}{{scope}} func {{funcName}}Streaming({{#inputShape}}_ input: {{.}}, {{/inputShape}}logger: {{logger}} = AWSClient.loggingDisabled, on eventLoop: EventLoop? = nil{{#streaming}}, _ stream: @escaping ({{.}}, EventLoop)->EventLoopFuture<Void>{{/streaming}}) -> EventLoopFuture<{{#outputShape}}{{.}}{{/outputShape}}{{^outputShape}}Void{{/outputShape}}> {
+            {{^outputShape}}@discardableResult {{/outputShape}}{{scope}} func {{funcName}}Streaming({{#inputShape}}_ input: {{.}}, {{/inputShape}}logger: {{logger}} = AWSClient.loggingDisabled, on eventLoop: EventLoop? = nil{{#streaming}}, _ stream: @escaping ({{.}}, EventLoop) -> EventLoopFuture<Void>{{/streaming}}) -> EventLoopFuture<{{#outputShape}}{{.}}{{/outputShape}}{{^outputShape}}Void{{/outputShape}}> {
                 return self.client.execute(operation: "{{name}}", path: "{{path}}", httpMethod: .{{httpMethod}}, serviceConfig: self.config{{#inputShape}}, input: input{{/inputShape}}{{#endpointRequired}}, endpointDiscovery: .init(storage: self.endpointStorage, discover: self.getEndpoint, required: {{required}}){{/endpointRequired}}{{#hostPrefix}}, hostPrefix: "{{{.}}}"{{/hostPrefix}}, logger: logger, on: eventLoop{{#streaming}}, stream: stream{{/streaming}})
             }
         {{/streamingOperations}}

--- a/Sources/SotoCodeGeneratorLib/Templates/comment.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/comment.swift
@@ -1,0 +1,12 @@
+extension Templates {
+    static let commentTemplate = """
+    {{%CONTENT_TYPE:TEXT}}
+    {{^empty(.)}}
+    /// {{.}}
+    {{/empty(.)}}
+    {{#empty(.)}}
+    ///{{.}}
+    {{/empty(.)}}
+
+    """
+}

--- a/Sources/SotoCodeGeneratorLib/Templates/comment.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/comment.swift
@@ -1,3 +1,17 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Soto for AWS open source project
+//
+// Copyright (c) 2017-2023 the Soto project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Soto project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
 extension Templates {
     static let commentTemplate = """
     {{%CONTENT_TYPE:TEXT}}

--- a/Sources/SotoCodeGeneratorLib/Templates/enum.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/enum.swift
@@ -42,5 +42,6 @@ extension Templates {
             {{scope}} var description: String { return self.rawValue }
         }
     {{/isExtensible}}
+
     """
 }

--- a/Sources/SotoCodeGeneratorLib/Templates/enum.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/enum.swift
@@ -25,7 +25,7 @@ extension Templates {
 
     {{#values}}
     {{#documentation}}
-            /// {{.}}
+            {{>comment}}
     {{/documentation}}
             {{scope}} static var {{case}}: Self { .init(rawValue: "{{rawValue}}") }
     {{/values}}
@@ -35,7 +35,7 @@ extension Templates {
         {{scope}} enum {{name}}: String, CustomStringConvertible, Codable, _SotoSendable {
     {{#values}}
     {{#documentation}}
-            /// {{.}}
+            {{>comment}}
     {{/documentation}}
             case {{case}}{{#rawValue}} = "{{.}}"{{/rawValue}}
     {{/values}}

--- a/Sources/SotoCodeGeneratorLib/Templates/enum.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/enum.swift
@@ -29,7 +29,6 @@ extension Templates {
             {{scope}} static var {{case}}: Self { .init(rawValue: "{{string}}")}
     {{/values}}
         }
-
     {{/isExtensible}}
     {{^isExtensible}}
         {{scope}} enum {{name}}: String, CustomStringConvertible, Codable, _SotoSendable {

--- a/Sources/SotoCodeGeneratorLib/Templates/enum.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/enum.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Soto for AWS open source project
 //
-// Copyright (c) 2017-2021 the Soto project authors
+// Copyright (c) 2017-2023 the Soto project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Sources/SotoCodeGeneratorLib/Templates/enum.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/enum.swift
@@ -37,7 +37,7 @@ extension Templates {
     {{#documentation}}
             {{>comment}}
     {{/documentation}}
-            case {{case}}{{#rawValue}} = "{{.}}"{{/rawValue}}
+            case {{case}} = "{{rawValue}}"
     {{/values}}
             {{scope}} var description: String { return self.rawValue }
         }

--- a/Sources/SotoCodeGeneratorLib/Templates/enum.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/enum.swift
@@ -22,11 +22,12 @@ extension Templates {
             {{scope}} init(rawValue: String) {
                 self.rawValue = rawValue
             }
+
     {{#values}}
     {{#documentation}}
             /// {{.}}
     {{/documentation}}
-            {{scope}} static var {{case}}: Self { .init(rawValue: "{{string}}")}
+            {{scope}} static var {{case}}: Self { .init(rawValue: "{{rawValue}}") }
     {{/values}}
         }
     {{/isExtensible}}
@@ -36,7 +37,7 @@ extension Templates {
     {{#documentation}}
             /// {{.}}
     {{/documentation}}
-            case {{case}} = "{{string}}"
+            case {{case}}{{#rawValue}} = "{{.}}"{{/rawValue}}
     {{/values}}
             {{scope}} var description: String { return self.rawValue }
         }

--- a/Sources/SotoCodeGeneratorLib/Templates/enumWithValues.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/enumWithValues.swift
@@ -143,5 +143,6 @@ extension Templates {
     {{/first(codingKeys)}}
     {{/first(members)}}
         }
+
     """#
 }

--- a/Sources/SotoCodeGeneratorLib/Templates/enumWithValues.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/enumWithValues.swift
@@ -113,7 +113,7 @@ extension Templates {
     {{/withDictionaryContexts(.)}}
     {{! validate min,max,pattern }}
     {{#sorted(reqs)}}
-                    try validate(value, name: "{{name}}", parent: name, {{key}}: {{value}})
+                    try self.validate(value, name: "{{name}}", parent: name, {{key}}: {{value}})
     {{/sorted(reqs)}}
     {{/validation}}
     {{#requiresDefaultValidation}}

--- a/Sources/SotoCodeGeneratorLib/Templates/enumWithValues.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/enumWithValues.swift
@@ -126,21 +126,21 @@ extension Templates {
     {{/first(validation)}}
     {{! CodingKeys enum }}
     {{#first(members)}}
-    {{^first(codingKeys)}}
+    {{#empty(codingKeys)}}
             private enum CodingKeys: CodingKey {}
-    {{/first(codingKeys)}}
-    {{#first(codingKeys)}}
+    {{/empty(codingKeys)}}
+    {{^empty(codingKeys)}}
             private enum CodingKeys: String, CodingKey {
     {{#codingKeys}}
-    {{#duplicate}}
-                case {{variable}} = "_{{codingKey}}" // TODO this is temporary measure for avoiding CodingKey duplication.
-    {{/duplicate}}
-    {{^duplicate}}
-                case {{variable}} = "{{codingKey}}"
-    {{/duplicate}}
+    {{#rawValue}}
+                case {{variable}} = "{{.}}"
+    {{/rawValue}}
+    {{^rawValue}}
+                case {{variable}}
+    {{/rawValue}}
     {{/codingKeys}}
             }
-    {{/first(codingKeys)}}
+    {{/empty(codingKeys)}}
     {{/first(members)}}
         }
 

--- a/Sources/SotoCodeGeneratorLib/Templates/enumWithValues.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/enumWithValues.swift
@@ -32,7 +32,7 @@ extension Templates {
     {{! enum cases }}
     {{#members}}
     {{#comment}}
-            /// {{.}}
+            {{>comment}}
     {{/comment}}
             case {{variable}}({{type}})
     {{/members}}

--- a/Sources/SotoCodeGeneratorLib/Templates/enumWithValues.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/enumWithValues.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Soto for AWS open source project
 //
-// Copyright (c) 2017-2021 the Soto project authors
+// Copyright (c) 2017-2023 the Soto project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Sources/SotoCodeGeneratorLib/Templates/error.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/error.swift
@@ -14,6 +14,7 @@
 
 extension Templates {
     static let errorTemplate = #"""
+    {{%CONTENT_TYPE:TEXT}}
     // MARK: - Errors
 
     /// Error enum for {{name}}
@@ -44,7 +45,7 @@ extension Templates {
 
     {{#errors}}
     {{#comment}}
-        /// {{.}}
+        {{>comment}}
     {{/comment}}
         {{scope}} static var {{enum}}: Self { .init(.{{enum}}) }
     {{/errors}}

--- a/Sources/SotoCodeGeneratorLib/Templates/error.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/error.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Soto for AWS open source project
 //
-// Copyright (c) 2017-2021 the Soto project authors
+// Copyright (c) 2017-2023 the Soto project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Sources/SotoCodeGeneratorLib/Templates/error.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/error.swift
@@ -14,7 +14,7 @@
 
 extension Templates {
     static let errorTemplate = #"""
-    // MARK - Errors
+    // MARK: - Errors
 
     /// Error enum for {{name}}
     {{scope}} struct {{errorName}}: AWSErrorType {
@@ -61,5 +61,6 @@ extension Templates {
             return "\(self.error.rawValue): \(self.message ?? "")"
         }
     }
+
     """#
 }

--- a/Sources/SotoCodeGeneratorLib/Templates/header.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/header.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Soto for AWS open source project
 //
-// Copyright (c) 2017-2022 the Soto project authors
+// Copyright (c) 2017-2023 the Soto project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Sources/SotoCodeGeneratorLib/Templates/header.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/header.swift
@@ -18,7 +18,7 @@ extension Templates {
     //
     // This source file is part of the Soto for AWS open source project
     //
-    // Copyright (c) 2017-2022 the Soto project authors
+    // Copyright (c) 2017-2023 the Soto project authors
     // Licensed under Apache License v2.0
     //
     // See LICENSE.txt for license information

--- a/Sources/SotoCodeGeneratorLib/Templates/paginators+async.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/paginators+async.swift
@@ -21,7 +21,12 @@ extension Templates {
     extension {{name}} {
     {{#paginators}}
     {{#operation.comment}}
+        {{^empty(.)}}
         ///  {{.}}
+        {{/empty(.)}}
+        {{#empty(.)}}
+        ///{{.}}
+        {{/empty(.)}}
     {{/operation.comment}}
         /// Return PaginatorSequence for operation.
         ///
@@ -30,7 +35,7 @@ extension Templates {
         ///   - logger: Logger used flot logging
         ///   - eventLoop: EventLoop to run this process on
     {{#operation.deprecated}}
-        @available(*, deprecated, message:"{{.}}")
+        @available(*, deprecated, message: "{{.}}")
     {{/operation.deprecated}}
         {{scope}} func {{operation.funcName}}Paginator(
             _ input: {{operation.inputShape}},

--- a/Sources/SotoCodeGeneratorLib/Templates/paginators+async.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/paginators+async.swift
@@ -39,7 +39,7 @@ extension Templates {
         ) -> AWSClient.PaginatorSequence<{{operation.inputShape}}, {{operation.outputShape}}> {
             return .init(
                 input: input,
-                command: {{operation.funcName}},
+                command: self.{{operation.funcName}},
     {{#inputKey}}
                 inputKey: \{{operation.inputShape}}.{{.}},
     {{/inputKey}}

--- a/Sources/SotoCodeGeneratorLib/Templates/paginators+async.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/paginators+async.swift
@@ -21,12 +21,7 @@ extension Templates {
     extension {{name}} {
     {{#paginators}}
     {{#operation.comment}}
-        {{^empty(.)}}
-        ///  {{.}}
-        {{/empty(.)}}
-        {{#empty(.)}}
-        ///{{.}}
-        {{/empty(.)}}
+        {{>comment}}
     {{/operation.comment}}
         /// Return PaginatorSequence for operation.
         ///

--- a/Sources/SotoCodeGeneratorLib/Templates/paginators+async.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/paginators+async.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Soto for AWS open source project
 //
-// Copyright (c) 2017-2021 the Soto project authors
+// Copyright (c) 2017-2023 the Soto project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Sources/SotoCodeGeneratorLib/Templates/paginators.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/paginators.swift
@@ -20,12 +20,7 @@ extension Templates {
     extension {{name}} {
     {{#paginators}}
     {{#operation.comment}}
-        {{^empty(.)}}
-        ///  {{.}}
-        {{/empty(.)}}
-        {{#empty(.)}}
-        ///{{.}}
-        {{/empty(.)}}
+        {{>comment}}
     {{/operation.comment}}
         ///
         /// Provide paginated results to closure `onPage` for it to combine them into one result.

--- a/Sources/SotoCodeGeneratorLib/Templates/paginators.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/paginators.swift
@@ -20,7 +20,12 @@ extension Templates {
     extension {{name}} {
     {{#paginators}}
     {{#operation.comment}}
+        {{^empty(.)}}
         ///  {{.}}
+        {{/empty(.)}}
+        {{#empty(.)}}
+        ///{{.}}
+        {{/empty(.)}}
     {{/operation.comment}}
         ///
         /// Provide paginated results to closure `onPage` for it to combine them into one result.
@@ -34,7 +39,7 @@ extension Templates {
         ///   - onPage: closure called with each paginated response. It combines an accumulating result with the contents of response. This combined result is then returned
         ///         along with a boolean indicating if the paginate operation should continue.
     {{#operation.deprecated}}
-        @available(*, deprecated, message:"{{.}}")
+        @available(*, deprecated, message: "{{.}}")
     {{/operation.deprecated}}
         {{scope}} func {{operation.funcName}}Paginator<Result>(
             _ input: {{operation.inputShape}},
@@ -70,7 +75,7 @@ extension Templates {
         ///   - eventLoop: EventLoop to run this process on
         ///   - onPage: closure called with each block of entries. Returns boolean indicating whether we should continue.
     {{#operation.deprecated}}
-        @available(*, deprecated, message:"{{.}}")
+        @available(*, deprecated, message: "{{.}}")
     {{/operation.deprecated}}
         {{scope}} func {{operation.funcName}}Paginator(
             _ input: {{operation.inputShape}},

--- a/Sources/SotoCodeGeneratorLib/Templates/paginators.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/paginators.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Soto for AWS open source project
 //
-// Copyright (c) 2017-2021 the Soto project authors
+// Copyright (c) 2017-2023 the Soto project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Sources/SotoCodeGeneratorLib/Templates/paginators.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/paginators.swift
@@ -43,10 +43,10 @@ extension Templates {
             on eventLoop: EventLoop? = nil,
             onPage: @escaping (Result, {{operation.outputShape}}, EventLoop) -> EventLoopFuture<(Bool, Result)>
         ) -> EventLoopFuture<Result> {
-            return client.paginate(
+            return self.client.paginate(
                 input: input,
                 initialValue: initialValue,
-                command: {{operation.funcName}},
+                command: self.{{operation.funcName}},
     {{#inputKey}}
                 inputKey: \{{operation.inputShape}}.{{.}},
                 outputKey: \{{operation.outputShape}}.{{outputKey}},
@@ -78,9 +78,9 @@ extension Templates {
             on eventLoop: EventLoop? = nil,
             onPage: @escaping ({{operation.outputShape}}, EventLoop) -> EventLoopFuture<Bool>
         ) -> EventLoopFuture<Void> {
-            return client.paginate(
+            return self.client.paginate(
                 input: input,
-                command: {{operation.funcName}},
+                command: self.{{operation.funcName}},
     {{#inputKey}}
                 inputKey: \{{operation.inputShape}}.{{.}},
                 outputKey: \{{operation.outputShape}}.{{outputKey}},
@@ -115,5 +115,6 @@ extension Templates {
 
     {{/last()}}
     {{/paginatorShapes}}
+
     """#
 }

--- a/Sources/SotoCodeGeneratorLib/Templates/shapes.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/shapes.swift
@@ -42,8 +42,8 @@ extension Templates {
     {{/struct}}
     {{/shapes}}
     }
-
     {{#errors}}
+
     {{>errors}}
     {{/errors}}
 

--- a/Sources/SotoCodeGeneratorLib/Templates/shapes.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/shapes.swift
@@ -34,6 +34,7 @@ extension Templates {
     {{>enumWithValues}}
     {{/enumWithValues}}
     {{/shapes}}
+
         // MARK: Shapes
     {{#shapes}}
     {{#struct}}

--- a/Sources/SotoCodeGeneratorLib/Templates/shapes.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/shapes.swift
@@ -34,7 +34,6 @@ extension Templates {
     {{>enumWithValues}}
     {{/enumWithValues}}
     {{/shapes}}
-
         // MARK: Shapes
     {{#shapes}}
     {{#struct}}

--- a/Sources/SotoCodeGeneratorLib/Templates/shapes.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/shapes.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Soto for AWS open source project
 //
-// Copyright (c) 2017-2021 the Soto project authors
+// Copyright (c) 2017-2023 the Soto project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Sources/SotoCodeGeneratorLib/Templates/struct.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/struct.swift
@@ -40,7 +40,11 @@ extension Templates {
     {{#encoding}}
     {{! Is encoding a dictionary }}
     {{#key}}
-            {{scope}} struct {{name}}: DictionaryCoderProperties { {{scope}} static let entry: String? = {{#entry}}"{{.}}"{{/entry}}{{^entry}}nil{{/entry}}; {{scope}} static let key = "{{key}}"; {{scope}} static let value = "{{value}}" }
+            {{scope}} struct {{name}}: DictionaryCoderProperties {
+                {{scope}} static let entry: String? = {{#entry}}"{{.}}"{{/entry}}{{^entry}}nil{{/entry}}
+                {{scope}} static let key = "{{key}}"
+                {{scope}} static let value = "{{value}}"
+            }
     {{/key}}
     {{^key}}
             {{scope}} struct {{name}}: ArrayCoderProperties { {{scope}} static let member = "{{member}}" }

--- a/Sources/SotoCodeGeneratorLib/Templates/struct.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/struct.swift
@@ -47,6 +47,7 @@ extension Templates {
 
     {{/encoding}}
     {{! Member variables }}
+    {{^empty(members)}}
     {{#members}}
     {{#comment}}
             {{>comment}}
@@ -57,9 +58,10 @@ extension Templates {
             {{scope}} {{#propertyWrapper}}var{{/propertyWrapper}}{{^propertyWrapper}}let{{/propertyWrapper}} {{variable}}: {{type}}
     {{/members}}
 
+    {{/empty(members)}}
     {{! init() function }}
     {{#empty(initParameters)}}
-            {{scopt}} init() {}
+            {{scope}} init() {}
     {{/empty(initParameters)}}
     {{^empty(initParameters)}}
             {{scope}} init({{#initParameters}}{{parameter}}: {{type}}{{#default}} = {{.}}{{/default}}{{^last()}}, {{/last()}}{{/initParameters}}) {
@@ -130,9 +132,9 @@ extension Templates {
     {{/validation}}
             }
     {{/first(validation)}}
-
     {{! CodingKeys enum }}
     {{^empty(members)}}
+
     {{#empty(codingKeys)}}
             private enum CodingKeys: CodingKey {}
     {{/empty(codingKeys)}}

--- a/Sources/SotoCodeGeneratorLib/Templates/struct.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/struct.swift
@@ -36,16 +36,18 @@ extension Templates {
             ]
 
     {{/first(awsShapeMembers)}}
+    {{^empty(encoding)}}
     {{#encoding}}
     {{! Is encoding a dictionary }}
     {{#key}}
-            {{scope}} struct {{name}}: DictionaryCoderProperties { static {{scope}} let entry: String? = {{#entry}}"{{.}}"{{/entry}}{{^entry}}nil{{/entry}}; static {{scope}} let key = "{{key}}"; static {{scope}} let value = "{{value}}" }
+            {{scope}} struct {{name}}: DictionaryCoderProperties { {{scope}} static let entry: String? = {{#entry}}"{{.}}"{{/entry}}{{^entry}}nil{{/entry}}; {{scope}} static let key = "{{key}}"; {{scope}} static let value = "{{value}}" }
     {{/key}}
     {{^key}}
-            {{scope}} struct {{name}}: ArrayCoderProperties { static {{scope}} let member = "{{member}}" }
+            {{scope}} struct {{name}}: ArrayCoderProperties { {{scope}} static let member = "{{member}}" }
     {{/key}}
-
     {{/encoding}}
+
+    {{/empty(encoding)}}
     {{! Member variables }}
     {{^empty(members)}}
     {{#members}}
@@ -60,10 +62,10 @@ extension Templates {
 
     {{/empty(members)}}
     {{! init() function }}
-    {{#empty(initParameters)}}
+    {{#empty(members)}}
             {{scope}} init() {}
-    {{/empty(initParameters)}}
-    {{^empty(initParameters)}}
+    {{/empty(members)}}
+    {{^empty(members)}}
             {{scope}} init({{#initParameters}}{{parameter}}: {{type}}{{#default}} = {{.}}{{/default}}{{^last()}}, {{/last()}}{{/initParameters}}) {
     {{#members}}
     {{^deprecated}}
@@ -74,10 +76,11 @@ extension Templates {
     {{/deprecated}}
     {{/members}}
             }
-    {{/empty(initParameters)}}
+    {{/empty(members)}}
     {{! deprecated init() function }}
     {{^empty(deprecatedMembers)}}
-            @available(*, deprecated, message:"Members {{#deprecatedMembers}}{{.}}{{^last()}}, {{/last()}}{{/deprecatedMembers}} have been deprecated")
+
+            @available(*, deprecated, message: "Members {{#deprecatedMembers}}{{.}}{{^last()}}, {{/last()}}{{/deprecatedMembers}} have been deprecated")
             {{scope}} init({{#members}}{{parameter}}: {{type}}{{#default}} = {{.}}{{/default}}{{^last()}}, {{/last()}}{{/members}}) {
     {{#members}}
                 self.{{variable}} = {{variable}}
@@ -141,12 +144,7 @@ extension Templates {
     {{^empty(codingKeys)}}
             private enum CodingKeys: String, CodingKey {
     {{#codingKeys}}
-    {{#rawValue}}
-                case {{variable}} = "{{.}}"
-    {{/rawValue}}
-    {{^rawValue}}
-                case {{variable}}
-    {{/rawValue}}
+                case {{variable}}{{#rawValue}} = "{{.}}"{{/rawValue}}
     {{/codingKeys}}
             }
     {{/empty(codingKeys)}}

--- a/Sources/SotoCodeGeneratorLib/Templates/struct.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/struct.swift
@@ -144,7 +144,7 @@ extension Templates {
     {{^empty(codingKeys)}}
             private enum CodingKeys: String, CodingKey {
     {{#codingKeys}}
-                case {{variable}}{{#rawValue}} = "{{.}}"{{/rawValue}}
+                case {{variable}} = "{{rawValue}}"
     {{/codingKeys}}
             }
     {{/empty(codingKeys)}}

--- a/Sources/SotoCodeGeneratorLib/Templates/struct.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/struct.swift
@@ -31,9 +31,10 @@ extension Templates {
     {{#first(awsShapeMembers)}}
             {{scope}} static var _encoding = [
     {{#awsShapeMembers}}
-                AWSMemberEncoding(label: "{{name}}"{{#location}}, location: {{.}}{{/location}}){{^last()}}, {{/last()}}
+                AWSMemberEncoding(label: "{{name}}"{{#location}}, location: {{.}}{{/location}}){{^last()}},{{/last()}}
     {{/awsShapeMembers}}
             ]
+
     {{/first(awsShapeMembers)}}
     {{#encoding}}
     {{! Is encoding a dictionary }}
@@ -43,8 +44,8 @@ extension Templates {
     {{^key}}
             {{scope}} struct {{name}}: ArrayCoderProperties { static {{scope}} let member = "{{member}}" }
     {{/key}}
-    {{/encoding}}
 
+    {{/encoding}}
     {{! Member variables }}
     {{#members}}
     {{#comment}}
@@ -133,16 +134,22 @@ extension Templates {
     {{#first(codingKeys)}}
             private enum CodingKeys: String, CodingKey {
     {{#codingKeys}}
+    {{#rawValue}}
     {{#duplicate}}
-                case {{variable}} = "_{{codingKey}}" // TODO this is temporary measure for avoiding CodingKey duplication.
+                case {{variable}} = "_{{.}}" // TODO this is temporary measure for avoiding CodingKey duplication.
     {{/duplicate}}
     {{^duplicate}}
-                case {{variable}} = "{{codingKey}}"
+                case {{variable}} = "{{.}}"
     {{/duplicate}}
+    {{/rawValue}}
+    {{^rawValue}}
+                case {{variable}}
+    {{/rawValue}}
     {{/codingKeys}}
             }
     {{/first(codingKeys)}}
     {{/first(members)}}
         }
+
     """#
 }

--- a/Sources/SotoCodeGeneratorLib/Templates/struct.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/struct.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Soto for AWS open source project
 //
-// Copyright (c) 2017-2021 the Soto project authors
+// Copyright (c) 2017-2023 the Soto project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Sources/SotoCodeGeneratorLib/Templates/struct.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/struct.swift
@@ -49,7 +49,7 @@ extension Templates {
     {{! Member variables }}
     {{#members}}
     {{#comment}}
-            /// {{.}}
+            {{>comment}}
     {{/comment}}
     {{#propertyWrapper}}
             {{.}}
@@ -58,6 +58,10 @@ extension Templates {
     {{/members}}
 
     {{! init() function }}
+    {{#empty(initParameters)}}
+            {{scopt}} init() {}
+    {{/empty(initParameters)}}
+    {{^empty(initParameters)}}
             {{scope}} init({{#initParameters}}{{parameter}}: {{type}}{{#default}} = {{.}}{{/default}}{{^last()}}, {{/last()}}{{/initParameters}}) {
     {{#members}}
     {{^deprecated}}
@@ -68,6 +72,7 @@ extension Templates {
     {{/deprecated}}
     {{/members}}
             }
+    {{/empty(initParameters)}}
     {{! deprecated init() function }}
     {{^empty(deprecatedMembers)}}
             @available(*, deprecated, message:"Members {{#deprecatedMembers}}{{.}}{{^last()}}, {{/last()}}{{/deprecatedMembers}} have been deprecated")
@@ -127,28 +132,23 @@ extension Templates {
     {{/first(validation)}}
 
     {{! CodingKeys enum }}
-    {{#first(members)}}
-    {{^first(codingKeys)}}
+    {{^empty(members)}}
+    {{#empty(codingKeys)}}
             private enum CodingKeys: CodingKey {}
-    {{/first(codingKeys)}}
-    {{#first(codingKeys)}}
+    {{/empty(codingKeys)}}
+    {{^empty(codingKeys)}}
             private enum CodingKeys: String, CodingKey {
     {{#codingKeys}}
     {{#rawValue}}
-    {{#duplicate}}
-                case {{variable}} = "_{{.}}" // TODO this is temporary measure for avoiding CodingKey duplication.
-    {{/duplicate}}
-    {{^duplicate}}
                 case {{variable}} = "{{.}}"
-    {{/duplicate}}
     {{/rawValue}}
     {{^rawValue}}
                 case {{variable}}
     {{/rawValue}}
     {{/codingKeys}}
             }
-    {{/first(codingKeys)}}
-    {{/first(members)}}
+    {{/empty(codingKeys)}}
+    {{/empty(members)}}
         }
 
     """#

--- a/Sources/SotoCodeGeneratorLib/Templates/waiters+async.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/waiters+async.swift
@@ -55,7 +55,7 @@ extension Templates {
     {{#maxDelayTime}}
                 maxDelayTime: .seconds({{.}}),
     {{/maxDelayTime}}
-                command: {{operation.funcName}}
+                command: self.{{operation.funcName}}
             )
             return try await self.client.waitUntil(input, waiter: waiter, maxWaitTime: maxWaitTime, logger: logger, on: eventLoop)
         }

--- a/Sources/SotoCodeGeneratorLib/Templates/waiters+async.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/waiters+async.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Soto for AWS open source project
 //
-// Copyright (c) 2017-2021 the Soto project authors
+// Copyright (c) 2017-2023 the Soto project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Sources/SotoCodeGeneratorLib/Templates/waiters+async.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/waiters+async.swift
@@ -59,7 +59,7 @@ extension Templates {
             )
             return try await self.client.waitUntil(input, waiter: waiter, maxWaitTime: maxWaitTime, logger: logger, on: eventLoop)
         }
-    {{#last()}}
+    {{^last()}}
 
     {{/last()}}
     {{/waiters}}

--- a/Sources/SotoCodeGeneratorLib/Templates/waiters.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/waiters.swift
@@ -20,7 +20,7 @@ extension Templates {
     extension {{name}} {
     {{#waiters}}
     {{#comment}}
-        /// {{.}}
+        {{>comment}}
     {{/comment}}
     {{#deprecated}}
         @available(*, deprecated)

--- a/Sources/SotoCodeGeneratorLib/Templates/waiters.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/waiters.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Soto for AWS open source project
 //
-// Copyright (c) 2017-2021 the Soto project authors
+// Copyright (c) 2017-2023 the Soto project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Sources/SotoCodeGeneratorLib/Templates/waiters.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/waiters.swift
@@ -60,7 +60,7 @@ extension Templates {
     {{#maxDelayTime}}
                 maxDelayTime: .seconds({{.}}),
     {{/maxDelayTime}}
-                command: {{operation.funcName}}
+                command: self.{{operation.funcName}}
             )
             return self.client.waitUntil(input, waiter: waiter, maxWaitTime: maxWaitTime, logger: logger, on: eventLoop)
         }
@@ -69,5 +69,6 @@ extension Templates {
     {{/last()}}
     {{/waiters}}
     }
+
     """
 }

--- a/Tests/SotoCodeGeneratorTests/StringTests.swift
+++ b/Tests/SotoCodeGeneratorTests/StringTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Soto for AWS open source project
 //
-// Copyright (c) 2017-2021 the Soto project authors
+// Copyright (c) 2017-2023 the Soto project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/SotoCodeGeneratorTests/StringTests.swift
+++ b/Tests/SotoCodeGeneratorTests/StringTests.swift
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Soto for AWS open source project
+//
+// Copyright (c) 2017-2021 the Soto project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Soto project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+@testable import SotoCodeGeneratorLib
+import XCTest
+
+/// Tests for String extensions
+final class StringTests: XCTestCase {
+    func testDropLast() {
+        let s = "abc  "
+        let result = s.dropLast { $0.isWhitespace }
+        XCTAssertEqual(result, "abc")
+    }
+
+    func testDropLastEmptyString() {
+        let s = "\t\t  "
+        let result = s.dropLast { $0.isWhitespace }
+        XCTAssertEqual(result, "")
+    }
+}


### PR DESCRIPTION
Remove swift format from code generator and edit templates to produce the same output. This reduces the number of dependencies and speeds up code generation.

There are some differences between generated code and swift formatted code. 
- Enum raw values don't assume a default value eg `case test` is now `case test = "test"`
- Numbers don't have `_` in them eg `100_000` is now `100000`

I could spend time duplicating these changes but it doesn't seem worth it.  