### PR TITLE
Generate response header decoding functions

### DIFF
--- a/Sources/SotoCodeGeneratorLib/AwsService+shapes.swift
+++ b/Sources/SotoCodeGeneratorLib/AwsService+shapes.swift
@@ -396,11 +396,6 @@ extension AwsService {
     func generateCodingKeyContext(_ member: MemberShape, name: String, isOutputShape: Bool) -> CodingKeysContext? {
         guard isMemberInBody(member, isOutputShape: isOutputShape),
               !(member.hasTrait(type: HttpPayloadTrait.self))
-        /*            (!member.hasTrait(type: HttpHeaderTrait.self) &&
-         !member.hasTrait(type: HttpPrefixHeadersTrait.self) &&
-         !member.hasTrait(type: HttpQueryTrait.self) &&
-         !member.hasTrait(type: HttpLabelTrait.self) &&
-         !(member.hasTrait(type: HttpPayloadTrait.self) && model.shape(for: member.target) is BlobShape))*/
         else {
             return nil
         }

--- a/Sources/SotoCodeGeneratorLib/AwsService+shapes.swift
+++ b/Sources/SotoCodeGeneratorLib/AwsService+shapes.swift
@@ -185,11 +185,13 @@ extension AwsService {
         }
         var decodeContext: DecodeContext?
         if isOutput {
+            let isResponse = shape.hasTrait(type: SotoResponseShapeTrait.self)
+            let hasCustomDecode = contexts.members.first { $0.decoding.fromCodable == nil } != nil
             decodeContext = .init(
-                isResponse: shape.hasTrait(type: SotoResponseShapeTrait.self),
-                requiresHeaders: contexts.members.first {
+                requiresResponse: contexts.members.first {
                     $0.decoding.fromHeader != nil || $0.decoding.fromStatusCode != nil || $0.decoding.fromRawPayload == true
-                } != nil
+                } != nil,
+                requiresDecodeInit: isResponse && hasCustomDecode
             )
         }
         return StructureContext(

--- a/Sources/SotoCodeGeneratorLib/AwsService+shapes.swift
+++ b/Sources/SotoCodeGeneratorLib/AwsService+shapes.swift
@@ -128,6 +128,8 @@ extension AwsService {
         var shapeOptions: [String] = []
         var xmlNamespace: String?
         let payloadMember = getPayloadMember(from: shape)
+        let isInput = shape.hasTrait(type: SotoInputShapeTrait.self)
+        let isOutput = shape.hasTrait(type: SotoOutputShapeTrait.self)
 
         guard let shapeProtocol = getShapeProtocol(shape, hasPayload: payloadMember != nil) else { return nil }
 
@@ -182,7 +184,7 @@ extension AwsService {
             object = recursive ? "final class" : "struct"
         }
         var decodeContext: DecodeContext?
-        if shape.hasTrait(type: SotoOutputShapeTrait.self) {
+        if isOutput {
             decodeContext = .init(
                 isResponse: shape.hasTrait(type: SotoResponseShapeTrait.self),
                 requiresHeaders: contexts.members.first {
@@ -194,10 +196,10 @@ extension AwsService {
             object: object,
             name: shapeName.toSwiftClassCase(),
             shapeProtocol: shapeProtocol,
-            payload: payloadMember?.key.toSwiftLabelCase(),
+            payload: isInput ? payloadMember?.key.toSwiftLabelCase() : nil,
             options: shapeOptions.count > 0 ? shapeOptions.map { ".\($0)" }.joined(separator: ", ") : nil,
             namespace: xmlNamespace,
-            isEncodable: shape.hasTrait(type: SotoInputShapeTrait.self),
+            isEncodable: isInput,
             decode: decodeContext,
             encoding: contexts.encoding,
             members: contexts.members,

--- a/Sources/SotoCodeGeneratorLib/AwsService.swift
+++ b/Sources/SotoCodeGeneratorLib/AwsService.swift
@@ -699,6 +699,9 @@ extension AwsService {
         let comment: [String.SubSequence]
         let deprecated: Bool
         var duplicate: Bool
+        var inBody: Bool
+        var inHeader: Bool
+        var isPayload: Bool
     }
 
     struct InitParamContext {
@@ -772,6 +775,7 @@ extension AwsService {
         let namespace: String?
         let isEncodable: Bool
         let isDecodable: Bool
+        let isResponse: Bool // is this the root response object
         let encoding: [EncodingPropertiesContext]
         let members: [MemberContext]
         let initParameters: [InitParamContext]

--- a/Sources/SotoCodeGeneratorLib/AwsService.swift
+++ b/Sources/SotoCodeGeneratorLib/AwsService.swift
@@ -776,8 +776,8 @@ extension AwsService {
     }
 
     struct DecodeContext {
-        let isResponse: Bool
-        let requiresHeaders: Bool
+        let requiresResponse: Bool
+        let requiresDecodeInit: Bool
     }
 
     struct StructureContext {

--- a/Sources/SotoCodeGeneratorLib/AwsService.swift
+++ b/Sources/SotoCodeGeneratorLib/AwsService.swift
@@ -689,6 +689,13 @@ extension AwsService {
         let value: String
     }
 
+    struct MemberDecodeContext {
+        var header: Bool?
+        var payload: Bool?
+        var rawPayload: Bool?
+        var codable: Bool?
+    }
+
     struct MemberContext {
         let variable: String
         let parameter: String
@@ -696,12 +703,11 @@ extension AwsService {
         let `default`: String?
         let propertyWrapper: String?
         let type: String
+        let nonOptionalType: String
         let comment: [String.SubSequence]
         let deprecated: Bool
         var duplicate: Bool
-        var inBody: Bool
-        var inHeader: Bool
-        var isPayload: Bool
+        var decoding: MemberDecodeContext
     }
 
     struct InitParamContext {
@@ -766,6 +772,11 @@ extension AwsService {
         var endpoints: [(region: String, hostname: String)] = []
     }
 
+    struct DecodeContext {
+        let isResponse: Bool
+        let requiresHeaders: Bool
+    }
+
     struct StructureContext {
         let object: String
         let name: String
@@ -774,8 +785,7 @@ extension AwsService {
         var options: String?
         let namespace: String?
         let isEncodable: Bool
-        let isDecodable: Bool
-        let isResponse: Bool // is this the root response object
+        let decode: DecodeContext?
         let encoding: [EncodingPropertiesContext]
         let members: [MemberContext]
         let initParameters: [InitParamContext]

--- a/Sources/SotoCodeGeneratorLib/AwsService.swift
+++ b/Sources/SotoCodeGeneratorLib/AwsService.swift
@@ -600,13 +600,13 @@ struct AwsService {
             if usedInOutput {
                 shapeProtocol += " & AWSDecodableShape"
             }
+            if hasPayload {
+                shapeProtocol += " & AWSShapeWithPayload"
+            }
         } else if usedInOutput {
             shapeProtocol = "AWSDecodableShape"
         } else {
             return nil
-        }
-        if hasPayload {
-            shapeProtocol += " & AWSShapeWithPayload"
         }
         return shapeProtocol
     }

--- a/Sources/SotoCodeGeneratorLib/Smithy+CodeGeneration.swift
+++ b/Sources/SotoCodeGeneratorLib/Smithy+CodeGeneration.swift
@@ -99,7 +99,7 @@ extension MemberShape {
             if memberShape.hasTrait(type: EnumTrait.self) { return self.target.shapeName.toSwiftClassCase() }
             return "String"
         } else if memberShape is BlobShape {
-            if self.hasTrait(type: HttpPayloadTrait.self) { return "HTTPBody" }
+            if self.hasTrait(type: HttpPayloadTrait.self) { return "AWSHTTPBody" }
             return "AWSBase64Data"
         } else if memberShape is CollectionShape {
             return self.target.shapeName.toSwiftClassCase()
@@ -123,7 +123,7 @@ extension MemberShape {
             if memberShape.hasTrait(type: EnumTrait.self) { return "\(withServiceName).\(self.target.shapeName.toSwiftClassCase())" }
             return "String"
         } else if memberShape is BlobShape {
-            if self.hasTrait(type: HttpPayloadTrait.self) { return "HTTPBody" }
+            if self.hasTrait(type: HttpPayloadTrait.self) { return "AWSHTTPBody" }
             return "AWSBase64Data"
         } else if memberShape is CollectionShape {
             return "\(withServiceName).\(self.target.shapeName.toSwiftClassCase())"

--- a/Sources/SotoCodeGeneratorLib/Templates/enumWithValues.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/enumWithValues.swift
@@ -36,7 +36,7 @@ extension Templates {
     {{/comment}}
             case {{variable}}({{type}})
     {{/members}}
-    {{#isDecodable}}
+    {{#decode}}
 
             {{scope}} init(from decoder: Decoder) throws {
                 let container = try decoder.container(keyedBy: CodingKeys.self)
@@ -55,7 +55,7 @@ extension Templates {
     {{/members}}
                 }
             }
-    {{/isDecodable}}
+    {{/decode}}
     {{#isEncodable}}
 
             {{scope}} func encode(to encoder: Encoder) throws {

--- a/Sources/SotoCodeGeneratorLib/Templates/struct.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/struct.swift
@@ -91,6 +91,20 @@ extension Templates {
     {{/members}}
             }
     {{/empty(deprecatedMembers)}}
+    {{#isResponse}}
+
+            {{scope}} init(from decoder: Decoder) throws {
+    {{#first(awsShapeMembers)}}
+                let response = decoder.userInfo[.awsResponse] as? AWSResponse
+    {{/first(awsShapeMembers)}}
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+    {{#members}}
+    {{#inBody}}            self.{{variable}} = try container.decode({{type}}.self, forKey: .{{variable}}){{/inBody}}
+    {{#inHeader}}            self.{{variable}} = response?.headerValue("{{variable}}"){{#default}} ?? {{.}}{{/default}}{{/inHeader}}
+    {{#isPayload}}            self.{{variable}} = request.body{{/isPayload}}
+    {{/members}}
+            }
+    {{/isResponse}}
     {{! validate() function }}
     {{#first(validation)}}
 

--- a/Sources/SotoCodeGeneratorLib/Templates/struct.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/struct.swift
@@ -59,7 +59,7 @@ extension Templates {
             {{>comment}}
     {{/comment}}
     {{#propertyWrapper}}
-            {{.}}
+            @{{.}}
     {{/propertyWrapper}}
             {{scope}} {{#propertyWrapper}}var{{/propertyWrapper}}{{^propertyWrapper}}let{{/propertyWrapper}} {{variable}}: {{type}}
     {{/members}}
@@ -101,7 +101,7 @@ extension Templates {
                 let container = try decoder.container(keyedBy: CodingKeys.self)
     {{/empty(codingKeys)}}
     {{#members}}{{#decoding}}{{#fromCodable}}
-                self.{{variable}} = try container.decode{{^required}}IfPresent{{/required}}({{decodeType}}.self, forKey: .{{variable}}){{/fromCodable}}{{#fromHeader}}
+                self.{{variable}} = try container.decode{{^propertyWrapper}}{{^required}}IfPresent{{/required}}{{/propertyWrapper}}({{decodeType}}.self, forKey: .{{variable}}){{#propertyWrapper}}.wrappedValue{{/propertyWrapper}}{{/fromCodable}}{{#fromHeader}}
                 self.{{variable}} = try response.decode{{^required}}IfPresent{{/required}}({{decodeType}}.self, forHeader: "{{.}}"){{/fromHeader}}{{#fromRawPayload}}
                 self.{{variable}} = response.decodePayload(){{/fromRawPayload}}{{#fromPayload}}
                 self.{{variable}} = try .init(from: decoder){{/fromPayload}}{{#fromStatusCode}}

--- a/Sources/SotoCodeGeneratorLib/Templates/struct.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/struct.swift
@@ -91,12 +91,12 @@ extension Templates {
     {{/members}}
             }
     {{/empty(deprecatedMembers)}}
-    {{#decode.isResponse}}
+    {{#decode.requiresDecodeInit}}
 
             {{scope}} init(from decoder: Decoder) throws {
-    {{#decode.requiresHeaders}}
+    {{#decode.requiresResponse}}
                 let response = decoder.userInfo[.awsResponse]! as! ResponseDecodingContainer
-    {{/decode.requiresHeaders}}
+    {{/decode.requiresResponse}}
     {{^empty(codingKeys)}}
                 let container = try decoder.container(keyedBy: CodingKeys.self)
     {{/empty(codingKeys)}}
@@ -108,7 +108,7 @@ extension Templates {
                 self.{{variable}} = response.decodeStatus(){{/fromStatusCode}}
     {{/decoding}}{{/members}}
             }
-    {{/decode.isResponse}}
+    {{/decode.requiresDecodeInit}}
     {{! validate() function }}
     {{#first(validation)}}
 


### PR DESCRIPTION
See https://github.com/soto-project/soto-core/pull/565 for more info

Needs to add special implementations of Codable `init(from decoder: Decoder) throws` functions where properties are stored in header, status code or as raw payload
eg This has now been added to `S3.DeleteObjectOutput`
```swift
      public init(from decoder: Decoder) throws {
          let response = decoder.userInfo[.awsResponse]! as! ResponseDecodingContainer
          self.deleteMarker = try response.decodeIfPresent(Bool.self, forHeader: "x-amz-delete-marker")
          self.requestCharged = try response.decodeIfPresent(RequestCharged.self, forHeader: "x-amz-request-charged")
          self.versionId = try response.decodeIfPresent(String.self, forHeader: "x-amz-version-id")

      }
```