### PR TITLE
Request encoding user info

### DIFF
--- a/Sources/SotoCodeGeneratorLib/AwsService+shapes.swift
+++ b/Sources/SotoCodeGeneratorLib/AwsService+shapes.swift
@@ -212,11 +212,14 @@ extension AwsService {
             let singleValueContainer = contexts.members.contains {
                 $0.memberCoding.isPayload == true || $0.memberCoding.isRawPayload == true
             }
+            // when setting values here. I am assuming that non root shapes must be events and require
+            // an event container instead of a request/response container. Also I am not outputting
+            // an encode for events as I don't support encoding tham at the moment
             codingContext = ShapeCodingContext(
                 requiresResponse: isRootShape && hasNonDecodableElements,
                 requiresEvent: !isRootShape && hasNonDecodableElements,
                 requiresDecodeInit: (hasCustomCodableElements || typeIsUnion) && isOutput,
-                requiresEncode: (hasCustomCodableElements || typeIsUnion) && isInput,
+                requiresEncode: ((hasCustomCodableElements && isRootShape) || typeIsUnion) && isInput,
                 singleValueContainer: singleValueContainer
             )
         }

--- a/Sources/SotoCodeGeneratorLib/AwsService+shapes.swift
+++ b/Sources/SotoCodeGeneratorLib/AwsService+shapes.swift
@@ -210,7 +210,7 @@ extension AwsService {
                 $0.memberCoding.isCodable == false && $0.memberCoding.isPayload == false
             }
             let singleValueContainer = contexts.members.contains {
-                $0.memberCoding.isPayload == true || $0.memberCoding.isRawPayload == true
+                $0.memberCoding.isPayload == true
             }
             // when setting values here. I am assuming that non root shapes must be events and require
             // an event container instead of a request/response container. Also I am not outputting
@@ -380,16 +380,12 @@ extension AwsService {
             memberCodableContext = .init(inURI: aliasTrait?.alias ?? name, codableType: type)
         } else if targetShape.hasTrait(type: StreamingTrait.self) {
             if targetShape is BlobShape {
-                memberCodableContext = .init(isRawPayload: true, codableType: type)
+                memberCodableContext = .init(isPayload: true, codableType: type)
             } else {
                 memberCodableContext = .init(isEventStream: true, codableType: type)
             }
         } else if member.hasTrait(type: HttpPayloadTrait.self) || member.hasTrait(type: EventPayloadTrait.self) {
-            if targetShape is BlobShape {
-                memberCodableContext = .init(isRawPayload: true, codableType: type)
-            } else {
-                memberCodableContext = .init(isPayload: true, codableType: type)
-            }
+            memberCodableContext = .init(isPayload: true, codableType: type)
         } else {
             // Codable needs to decode property wrapper if it exists
             memberCodableContext = .init(isCodable: true, codableType: propertyWrapper ?? type)

--- a/Sources/SotoCodeGeneratorLib/AwsService+shapes.swift
+++ b/Sources/SotoCodeGeneratorLib/AwsService+shapes.swift
@@ -378,13 +378,10 @@ extension AwsService {
         } else if member.hasTrait(type: HttpLabelTrait.self), !isOutputShape {
             let aliasTrait = member.trait(named: serviceProtocolTrait.nameTrait.staticName) as? AliasTrait
             memberCodableContext = .init(inURI: aliasTrait?.alias ?? name, codableType: type)
-        } else if targetShape.hasTrait(type: StreamingTrait.self) {
-            if targetShape is BlobShape {
-                memberCodableContext = .init(isPayload: true, codableType: type)
-            } else {
-                memberCodableContext = .init(isEventStream: true, codableType: type)
-            }
-        } else if member.hasTrait(type: HttpPayloadTrait.self) || member.hasTrait(type: EventPayloadTrait.self) {
+        } else if member.hasTrait(type: HttpPayloadTrait.self) ||
+            member.hasTrait(type: EventPayloadTrait.self) ||
+            targetShape.hasTrait(type: StreamingTrait.self)
+        {
             memberCodableContext = .init(isPayload: true, codableType: type)
         } else {
             // Codable needs to decode property wrapper if it exists

--- a/Sources/SotoCodeGeneratorLib/AwsService.swift
+++ b/Sources/SotoCodeGeneratorLib/AwsService.swift
@@ -603,9 +603,6 @@ struct AwsService {
             if usedInOutput {
                 shapeProtocol += " & AWSDecodableShape"
             }
-            if hasPayload {
-                shapeProtocol += " & AWSShapeWithPayload"
-            }
         } else if usedInOutput {
             shapeProtocol = "AWSDecodableShape"
         } else {
@@ -695,12 +692,42 @@ extension AwsService {
     }
 
     struct MemberCodableContext {
-        var header: String?
-        var payload: Bool?
-        var rawPayload: Bool?
-        var eventStream: Bool?
-        var codable: Bool?
-        var statusCode: Bool?
+        internal init(
+            inHeader: String? = nil,
+            inQuery: String? = nil,
+            inURI: String? = nil,
+            inHostPrefix: String? = nil,
+            areQueryParams: Bool = false,
+            isPayload: Bool = false,
+            isRawPayload: Bool = false,
+            isEventStream: Bool = false,
+            isCodable: Bool = false,
+            isStatusCode: Bool = false,
+            codableType: String
+        ) {
+            self.inHeader = inHeader
+            self.inQuery = inQuery
+            self.inURI = inURI
+            self.inHostPrefix = inHostPrefix
+            self.areQueryParams = areQueryParams
+            self.isPayload = isPayload
+            self.isRawPayload = isRawPayload
+            self.isEventStream = isEventStream
+            self.isCodable = isCodable
+            self.isStatusCode = isStatusCode
+            self.codableType = codableType
+        }
+
+        var inHeader: String?
+        var inQuery: String?
+        var inURI: String?
+        var inHostPrefix: String?
+        var areQueryParams: Bool
+        var isPayload: Bool
+        var isRawPayload: Bool
+        var isEventStream: Bool
+        var isCodable: Bool
+        var isStatusCode: Bool
         var codableType: String
     }
 
@@ -784,15 +811,16 @@ extension AwsService {
         let requiresEvent: Bool
         let requiresDecodeInit: Bool
         let requiresEncode: Bool
+        let singleValueContainer: Bool
     }
 
     struct StructureContext {
         let object: String
         let name: String
         let shapeProtocol: String
-        let payload: String?
         var options: String?
         let namespace: String?
+        let xmlRootNodeName: String?
         let shapeCoding: ShapeCodingContext?
         let encoding: [EncodingPropertiesContext]
         let members: [MemberContext]

--- a/Sources/SotoCodeGeneratorLib/AwsService.swift
+++ b/Sources/SotoCodeGeneratorLib/AwsService.swift
@@ -694,14 +694,14 @@ extension AwsService {
         let value: String
     }
 
-    struct MemberDecodeContext {
-        var fromHeader: String?
-        var fromPayload: Bool?
-        var fromRawPayload: Bool?
-        var fromEventStream: Bool?
-        var fromCodable: Bool?
-        var fromStatusCode: Bool?
-        var decodeType: String
+    struct MemberCodableContext {
+        var header: String?
+        var payload: Bool?
+        var rawPayload: Bool?
+        var eventStream: Bool?
+        var codable: Bool?
+        var statusCode: Bool?
+        var codableType: String
     }
 
     struct MemberContext {
@@ -714,7 +714,7 @@ extension AwsService {
         let comment: [String.SubSequence]
         let deprecated: Bool
         var duplicate: Bool
-        var decoding: MemberDecodeContext
+        var memberCoding: MemberCodableContext
     }
 
     struct InitParamContext {
@@ -779,10 +779,11 @@ extension AwsService {
         var endpoints: [(region: String, hostname: String)] = []
     }
 
-    struct DecodeContext {
+    struct ShapeCodingContext {
         let requiresResponse: Bool
         let requiresEvent: Bool
         let requiresDecodeInit: Bool
+        let requiresEncode: Bool
     }
 
     struct StructureContext {
@@ -792,8 +793,7 @@ extension AwsService {
         let payload: String?
         var options: String?
         let namespace: String?
-        let isEncodable: Bool
-        let decode: DecodeContext?
+        let shapeCoding: ShapeCodingContext?
         let encoding: [EncodingPropertiesContext]
         let members: [MemberContext]
         let initParameters: [InitParamContext]

--- a/Sources/SotoCodeGeneratorLib/AwsService.swift
+++ b/Sources/SotoCodeGeneratorLib/AwsService.swift
@@ -699,7 +699,6 @@ extension AwsService {
             inHostPrefix: String? = nil,
             areQueryParams: Bool = false,
             isPayload: Bool = false,
-            isRawPayload: Bool = false,
             isEventStream: Bool = false,
             isCodable: Bool = false,
             isStatusCode: Bool = false,
@@ -711,7 +710,6 @@ extension AwsService {
             self.inHostPrefix = inHostPrefix
             self.areQueryParams = areQueryParams
             self.isPayload = isPayload
-            self.isRawPayload = isRawPayload
             self.isEventStream = isEventStream
             self.isCodable = isCodable
             self.isStatusCode = isStatusCode
@@ -724,7 +722,6 @@ extension AwsService {
         var inHostPrefix: String?
         var areQueryParams: Bool
         var isPayload: Bool
-        var isRawPayload: Bool
         var isEventStream: Bool
         var isCodable: Bool
         var isStatusCode: Bool

--- a/Sources/SotoCodeGeneratorLib/AwsService.swift
+++ b/Sources/SotoCodeGeneratorLib/AwsService.swift
@@ -615,6 +615,7 @@ struct AwsService {
         return !(member.hasTrait(type: HttpHeaderTrait.self) ||
             member.hasTrait(type: HttpPrefixHeadersTrait.self) ||
             (member.hasTrait(type: HttpQueryTrait.self) && !isOutputShape) ||
+            member.hasTrait(type: HttpQueryParamsTrait.self) ||
             member.hasTrait(type: HttpLabelTrait.self) ||
             member.hasTrait(type: HttpResponseCodeTrait.self))
     }
@@ -699,7 +700,6 @@ extension AwsService {
             inHostPrefix: String? = nil,
             areQueryParams: Bool = false,
             isPayload: Bool = false,
-            isEventStream: Bool = false,
             isCodable: Bool = false,
             isStatusCode: Bool = false,
             codableType: String
@@ -710,7 +710,6 @@ extension AwsService {
             self.inHostPrefix = inHostPrefix
             self.areQueryParams = areQueryParams
             self.isPayload = isPayload
-            self.isEventStream = isEventStream
             self.isCodable = isCodable
             self.isStatusCode = isStatusCode
             self.codableType = codableType
@@ -722,7 +721,6 @@ extension AwsService {
         var inHostPrefix: String?
         var areQueryParams: Bool
         var isPayload: Bool
-        var isEventStream: Bool
         var isCodable: Bool
         var isStatusCode: Bool
         var codableType: String

--- a/Sources/SotoCodeGeneratorLib/Smithy+CodeGeneration.swift
+++ b/Sources/SotoCodeGeneratorLib/Smithy+CodeGeneration.swift
@@ -100,7 +100,7 @@ extension MemberShape {
             return "String"
         } else if memberShape is BlobShape {
             if self.hasTrait(type: HttpPayloadTrait.self) { return "AWSHTTPBody" }
-            else if self.hasTrait(type: EventPayloadTrait.self) { return "ByteBuffer" }
+            else if self.hasTrait(type: EventPayloadTrait.self) { return "AWSEventPayload" }
             return "AWSBase64Data"
         } else if memberShape is CollectionShape {
             if memberShape.hasTrait(type: StreamingTrait.self) {

--- a/Sources/SotoCodeGeneratorLib/Templates/enumWithValues.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/enumWithValues.swift
@@ -36,7 +36,7 @@ extension Templates {
     {{/comment}}
             case {{variable}}({{type}})
     {{/members}}
-    {{#decode}}
+    {{#shapeCoding.requiresDecodeInit}}
 
             {{scope}} init(from decoder: Decoder) throws {
                 let container = try decoder.container(keyedBy: CodingKeys.self)
@@ -55,8 +55,8 @@ extension Templates {
     {{/members}}
                 }
             }
-    {{/decode}}
-    {{#isEncodable}}
+    {{/shapeCoding.requiresDecodeInit}}
+    {{#shapeCoding.requiresEncode}}
 
             {{scope}} func encode(to encoder: Encoder) throws {
                 var container = encoder.container(keyedBy: CodingKeys.self)
@@ -67,7 +67,7 @@ extension Templates {
     {{/members}}
                 }
             }
-    {{/isEncodable}}
+    {{/shapeCoding.requiresEncode}}
 
     {{! validate() function }}
     {{#first(validation)}}

--- a/Sources/SotoCodeGeneratorLib/Templates/struct.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/struct.swift
@@ -91,28 +91,28 @@ extension Templates {
     {{/members}}
             }
     {{/empty(deprecatedMembers)}}
-    {{#decode.requiresDecodeInit}}
+    {{#shapeCoding.requiresDecodeInit}}
 
             {{scope}} init(from decoder: Decoder) throws {
-    {{#decode.requiresResponse}}
+    {{#shapeCoding.requiresResponse}}
                 let response = decoder.userInfo[.awsResponse]! as! ResponseDecodingContainer
-    {{/decode.requiresResponse}}
-    {{#decode.requiresEvent}}
+    {{/shapeCoding.requiresResponse}}
+    {{#shapeCoding.requiresEvent}}
                 let response = decoder.userInfo[.awsEvent]! as! EventDecodingContainer
-    {{/decode.requiresEvent}}
+    {{/shapeCoding.requiresEvent}}
     {{^empty(codingKeys)}}
                 let container = try decoder.container(keyedBy: CodingKeys.self)
     {{/empty(codingKeys)}}
-    {{#members}}{{#decoding}}{{#fromCodable}}
-                self.{{variable}} = try container.decode{{^propertyWrapper}}{{^required}}IfPresent{{/required}}{{/propertyWrapper}}({{decodeType}}.self, forKey: .{{variable}}){{#propertyWrapper}}.wrappedValue{{/propertyWrapper}}{{/fromCodable}}{{#fromHeader}}
-                self.{{variable}} = try response.decode{{^required}}IfPresent{{/required}}({{decodeType}}.self, forHeader: "{{.}}"){{/fromHeader}}{{#fromRawPayload}}
-                self.{{variable}} = response.decodePayload(){{/fromRawPayload}}{{#fromEventStream}}
-                self.{{variable}} = response.decodeEventStream(){{/fromEventStream}}{{#fromPayload}}
-                self.{{variable}} = try .init(from: decoder){{/fromPayload}}{{#fromStatusCode}}
-                self.{{variable}} = response.decodeStatus(){{/fromStatusCode}}
-    {{/decoding}}{{/members}}
+    {{#members}}{{#memberCoding}}{{#codable}}
+                self.{{variable}} = try container.decode{{^propertyWrapper}}{{^required}}IfPresent{{/required}}{{/propertyWrapper}}({{codableType}}.self, forKey: .{{variable}}){{#propertyWrapper}}.wrappedValue{{/propertyWrapper}}{{/codable}}{{#header}}
+                self.{{variable}} = try response.decode{{^required}}IfPresent{{/required}}({{codableType}}.self, forHeader: "{{.}}"){{/header}}{{#rawPayload}}
+                self.{{variable}} = response.decodePayload(){{/rawPayload}}{{#eventStream}}
+                self.{{variable}} = response.decodeEventStream(){{/eventStream}}{{#payload}}
+                self.{{variable}} = try .init(from: decoder){{/payload}}{{#statusCode}}
+                self.{{variable}} = response.decodeStatus(){{/statusCode}}
+    {{/memberCoding}}{{/members}}
             }
-    {{/decode.requiresDecodeInit}}
+    {{/shapeCoding.requiresDecodeInit}}
     {{! validate() function }}
     {{#first(validation)}}
 

--- a/Sources/SotoCodeGeneratorLib/Templates/struct.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/struct.swift
@@ -142,7 +142,7 @@ extension Templates {
     {{/shapeCoding.singleValueContainer}}
     {{#members}}{{#memberCoding}}
     {{#isCodable}}
-                try container.encode(self.{{variable}}, forKey: .{{variable}})
+                try container.encode{{^required}}IfPresent{{/required}}(self.{{variable}}, forKey: .{{variable}})
     {{/isCodable}}
     {{#inHeader}}
                 request.encodeHeader(self.{{#propertyWrapper}}_{{/propertyWrapper}}{{variable}}, key: "{{.}}")

--- a/Sources/SotoCodeGeneratorLib/Templates/struct.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/struct.swift
@@ -112,11 +112,8 @@ extension Templates {
                 self.{{variable}} = try container.decode{{^propertyWrapper}}{{^required}}IfPresent{{/required}}{{/propertyWrapper}}({{codableType}}.self, forKey: .{{variable}}){{#propertyWrapper}}.wrappedValue{{/propertyWrapper}}
     {{/isCodable}}
     {{#inHeader}}
-                self.{{variable}} = try response.decode{{^required}}IfPresent{{/required}}({{codableType}}.self, forHeader: "{{.}}")
+                self.{{variable}} = try response.decodeHeader{{^required}}IfPresent{{/required}}({{codableType}}.self, key: "{{.}}")
     {{/inHeader}}
-    {{#isEventStream}}
-                self.{{variable}} = response.decodeEventStream()
-    {{/isEventStream}}
     {{#isPayload}}
                 self.{{variable}} = try container.decode({{codableType}}.self)
     {{/isPayload}}


### PR DESCRIPTION
- Clean up response decoding so we can use the same code for both requests and responses
- Add support for generating `encode(to:)` functions using new `RequestEncodingContainer`.
- All payload types are treated the same