### PR TITLE
Filter shapes when a filter has been applied to operations

### DIFF
--- a/Sources/SotoCodeGeneratorLib/AwsService+shapes.swift
+++ b/Sources/SotoCodeGeneratorLib/AwsService+shapes.swift
@@ -134,6 +134,7 @@ extension AwsService {
         let isInput = shape.hasTrait(type: SotoInputShapeTrait.self)
         let isOutput = shape.hasTrait(type: SotoOutputShapeTrait.self)
 
+        // Return if decodable, encodable or both. If none of these then don't output the shape
         guard let shapeProtocol = getShapeProtocol(shape, hasPayload: payloadMember != nil) else { return nil }
 
         let contexts = self.generateMembersContexts(shape, shapeName: shapeName, typeIsUnion: typeIsUnion)

--- a/Sources/SotoCodeGeneratorLib/SotoCodeGen.swift
+++ b/Sources/SotoCodeGeneratorLib/SotoCodeGen.swift
@@ -80,21 +80,20 @@ public struct SotoCodeGen {
                         } else {
                             model = try self.loadJSONAST(filename: file)
                         }
-                        var service = try AwsService(
-                            model,
-                            endpoints: endpoints,
-                            outputHTMLComments: self.command.htmlComments,
-                            logger: self.logger
-                        )
                         // get service filename without path and extension
                         let filename =
                             file
                             .split(separator: "/", omittingEmptySubsequences: true).last!
                         let filenameWithoutExtension = String(filename[..<(filename.lastIndex(of: ".") ?? filename.endIndex)])
+                        let filter = config.services?[filenameWithoutExtension]?.operations
+                        let service = try AwsService(
+                            model,
+                            endpoints: endpoints,
+                            filter: filter,
+                            outputHTMLComments: self.command.htmlComments,
+                            logger: self.logger
+                        )
 
-                        if let serviceConfig = config.services?[filenameWithoutExtension], let filter = serviceConfig.operations {
-                            service.filterOperations(filter)
-                        }
                         if self.command.output {
                             try self.generateFiles(with: service, config: config)
                         }


### PR DESCRIPTION
If running the code generator with a filter on operations, the filter should also be applied to the shapes generated. No point generating request/response structures for operations that aren't being output.

Shapes are only output if they are have `SotoInputShapeTrait` or `SotoOutputShapeTrait`. These traits are added when `AwsService` is initialised. If parses all the operations and the shapes they reference and adds the traits where applicable. Previously this process was done before the operations were filtered, this change filters the operations before marking up the shapes.