### PR TITLE
Enum cases that are unit should have no associated value

### DIFF
--- a/Sources/SotoCodeGeneratorLib/AwsService+shapes.swift
+++ b/Sources/SotoCodeGeneratorLib/AwsService+shapes.swift
@@ -384,6 +384,8 @@ extension AwsService {
             || targetShape.hasTrait(type: StreamingTrait.self)
         {
             memberCodableContext = .init(isPayload: true, codableType: type)
+        } else if model.shape(for: member.target)?.hasTrait(type: UnitTypeTrait.self) == true {
+            memberCodableContext = .init(isUnit: true, codableType: type)
         } else {
             // Codable needs to decode property wrapper if it exists
             memberCodableContext = .init(isCodable: true, codableType: propertyWrapper ?? type)

--- a/Sources/SotoCodeGeneratorLib/AwsService.swift
+++ b/Sources/SotoCodeGeneratorLib/AwsService.swift
@@ -886,6 +886,7 @@ extension AwsService {
             inURI: String? = nil,
             inHostPrefix: String? = nil,
             areQueryParams: Bool = false,
+            isUnit: Bool = false,
             isPayload: Bool = false,
             isCodable: Bool = false,
             isStatusCode: Bool = false,
@@ -896,6 +897,7 @@ extension AwsService {
             self.inURI = inURI
             self.inHostPrefix = inHostPrefix
             self.areQueryParams = areQueryParams
+            self.isUnit = isUnit
             self.isPayload = isPayload
             self.isCodable = isCodable
             self.isStatusCode = isStatusCode
@@ -907,6 +909,7 @@ extension AwsService {
         var inURI: String?
         var inHostPrefix: String?
         var areQueryParams: Bool
+        var isUnit: Bool
         var isPayload: Bool
         var isCodable: Bool
         var isStatusCode: Bool

--- a/Sources/SotoCodeGeneratorLib/Templates/enumWithValues.swift
+++ b/Sources/SotoCodeGeneratorLib/Templates/enumWithValues.swift
@@ -34,7 +34,12 @@ extension Templates {
         {{#comment}}
                 {{>comment}}
         {{/comment}}
+        {{^memberCoding.isUnit}}
                 case {{variable}}({{type}})
+        {{/memberCoding.isUnit}}
+        {{#memberCoding.isUnit}}
+                case {{variable}}
+        {{/memberCoding.isUnit}}
         {{/members}}
         {{#shapeCoding.requiresDecodeInit}}
 
@@ -50,8 +55,13 @@ extension Templates {
                     switch key {
         {{#members}}
                     case .{{variable}}:
+        {{^memberCoding.isUnit}}
                         let value = try container.decode({{type}}.self, forKey: .{{variable}})
                         self = .{{variable}}(value)
+        {{/memberCoding.isUnit}}
+        {{#memberCoding.isUnit}}
+                        self = .{{variable}}
+        {{/memberCoding.isUnit}}
         {{/members}}
                     }
                 }
@@ -62,8 +72,14 @@ extension Templates {
                     var container = encoder.container(keyedBy: CodingKeys.self)
                     switch self {
         {{#members}}
+        {{^memberCoding.isUnit}}
                     case .{{variable}}(let value):
                         try container.encode(value, forKey: .{{variable}})
+        {{/memberCoding.isUnit}}
+        {{#memberCoding.isUnit}}
+                    case .{{variable}}:
+                        try container.encode([String: String](), forKey: .{{variable}})
+        {{/memberCoding.isUnit}}
         {{/members}}
                     }
                 }


### PR DESCRIPTION
Union members which have a unit type should have no associated type when rendered as enums with associated types.

eg
```swift
public enum EventFilter: AWSEncodableShape & AWSDecodableShape, Sendable {
        case all
        case include([Event])
}
```

instead of 
```swift
public enum EventFilter: AWSEncodableShape & AWSDecodableShape, Sendable {
        case all(Void)
        case include([Event])
}
```
